### PR TITLE
Scaffold layered NTCIP Manager architecture (asyncio + pysnmp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,19 @@ precommit:
 	pre-commit run --all-files
 
 test:
-	PYTHONPATH=src pytest -v --tb=short tests
+	PYTHONPATH=src python -m pytest -v --tb=short tests
 
 test-cov:
-	PYTHONPATH=src pytest -v --tb=short --cov=src --cov-report=term-missing tests
+	PYTHONPATH=src python -m pytest -v --tb=short --cov=src --cov-report=term-missing tests
 
 test-ntcip:
-	PYTHONPATH=src pytest -v --tb=long tests/ntcip
+	PYTHONPATH=src python -m pytest -v --tb=long tests/ntcip
+
+test-its:
+	PYTHONPATH=src python -m pytest -v --tb=long tests/its
+
+test-lab:
+	PYTHONPATH=src python -m pytest -v --tb=long tests/its tests/ntcip
 
 clean:
 	rm -rf .pytest_cache .mypy_cache .coverage htmlcov build dist *.egg-info

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ precommit:
 	pre-commit run --all-files
 
 test:
-	pytest --cov=src --cov-report=term-missing
+	PYTHONPATH=src pytest -v --tb=short tests
+
+test-cov:
+	PYTHONPATH=src pytest -v --tb=short --cov=src --cov-report=term-missing tests
+
+test-ntcip:
+	PYTHONPATH=src pytest -v --tb=long tests/ntcip
 
 clean:
 	rm -rf .pytest_cache .mypy_cache .coverage htmlcov build dist *.egg-info

--- a/README.md
+++ b/README.md
@@ -1,99 +1,74 @@
-# GIS-Based Location Map with Traffic Signal Nodes
+# ITS Systems Lab
 
-Modular Python repo for rapid experimentation.
+Personal workbench to **learn, replicate, and innovate** across Intelligent
+Transportation Systems -- CCTV, data stations, RWIS, VMS, signals, tunnel
+crossovers, plus a sandboxed airport learning area.
 
-## Features
+**Returning to this repo?** Open [`START_HERE.md`](START_HERE.md) first.
 
-- Visualize traffic signal nodes on a map
-- Integrate real-time data from APIs
-- Save and load traffic signal data from JSON files
-- Modular design for easy extension
+| Doc | Why |
+|-----|-----|
+| [`START_HERE.md`](START_HERE.md) | 5-minute re-entry |
+| [`docs/ITS_LAB_STRATEGY.md`](docs/ITS_LAB_STRATEGY.md) | Mission, domains, rules |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Locked platform seams |
+| [`docs/ROADMAP.md`](docs/ROADMAP.md) | Ordered next steps |
 
-## Usage
-
-```bash
-poetry install
-python src/cli/main.py
-```
-
-## Features
-
-### Signal Indication Layout
-
-The system displays traffic signal phases arranged by intersection legs in an ASCII cross-shaped layout:
+## Quick demos
 
 ```bash
-# Show compact layout (fits 80-column terminal)
-python src/cli/main.py layout
+# ITS platform shadow demo (signals adapter + policy)
+PYTHONPATH=src python -m its
 
-# Show full layout with complete descriptions
-python src/cli/main.py layout --full
+# NTCIP Manager GET phase status (stub ASC)
+PYTHONPATH=src python -m ntcip
 
-# Show layout with signal states (R=Red, Y=Yellow, G=Green)
+# Existing 8-phase layout / sim CLI
 python src/cli/main.py layout --states
-```
-
-### Signal Cycle Simulation
-
-Run a simulation showing signal phase transitions:
-
-```bash
 python src/cli/main.py simulate
+
+# Tests (verbose)
+PYTHONPATH=src python -m pytest -v tests/its tests/ntcip
 ```
 
-### Demo Mode
+## Layout
 
-View all available layout demonstrations:
+| Path | Role |
+|------|------|
+| `src/its/` | Shared platform: profiles, adapters, policies, shadow bus |
+| `src/ntcip/` | NTCIP Manager stack (protocol / MIB / business) |
+| `src/cli/` | Signal layout and cycle simulation |
+| `profiles/` | Sanitized device packs |
+| `captures/` | Anonymized traces |
+| `playbooks/` | Ops-language runbooks |
+| `domains/` | Per-asset notes (vms, rwis, cctv, tunnel, ...) |
+| `airport_lab/` | Airport security learning -- synthetic only |
+| `mibs/` | NTCIP SMI snippets |
+
+## Promotion path
+
+```
+capture -> model -> simulate -> shadow -> field
+```
+
+Policies default to **shadow / dry-run**. No production secrets in git.
+Airport work stays in `airport_lab/` until you have explicit authority.
+
+## Signal layout (legacy CLI)
+
+Phases by intersection leg:
+
+- North: 1 (left), 6 (through)
+- South: 2 (left), 5 (through)
+- East: 3 (left), 8 (through)
+- West: 7 (through), 4 (left)
 
 ```bash
+python src/cli/main.py layout --full
+python src/cli/main.py layout --states
 python src/cli/main.py demo
 ```
 
-## Intersection Leg Arrangement
-
-Phases are arranged by intersection legs:
-- **North leg**: Phases 1 (left) & 6 (through)
-- **South leg**: Phases 2 (left) & 5 (through)  
-- **East leg**: Phases 3 (left) & 8 (through)
-- **West leg**: Phases 7 (through) & 4 (left)
-
-Example compact layout output:
-
-```
-                [1: NB Left]  [6: NB Thru]
-[7: WB Thru]  [4: WB Left]      [3: EB Left]  [8: EB Thru]
-                [2: SB Left]  [5: SB Thru]
-```
-
-With signal states:
-
-```
-                    [1: NB Left (G)]  [6: NB Thru (G)]
-[7: WB Thru (R)]  [4: WB Left (R)]      [3: EB Left (R)]  [8: EB Thru (R)]
-                    [2: SB Left (R)]  [5: SB Thru (R)]
-```
-
-## NTCIP Manager Scaffold
-
-Three-layer NTCIP architecture (Manager-side GET/SET) lives under `src/ntcip/`:
-
-1. **Protocol Engine** (`ntcip.protocol`) -- async SNMP via pluggable backend (pysnmp seam + stub)
-2. **Object & MIB** (`ntcip.mib`) -- OID registry, ASN.1 types, NTCIP DateAndTime
-3. **Business Logic** (`ntcip.business`) -- `NtcipManager` facade and adapters
-
-```bash
-# Offline demo: async GET of ASC phase status (stub backend)
-PYTHONPATH=src python -m ntcip
-
-# NTCIP unit tests (verbose)
-make test-ntcip
-```
-
-See `docs/ntcip_architecture.md` for layering details and standard references.
-
 ## Contributing
 
-See `CONTRIBUTING.md`
-
-![Tests](https://github.com/user/repo/actions/workflows/main.yml/badge.svg)
-![License](https://img.shields.io/github/license/user/repo.svg)
+See `CONTRIBUTING.md`. Prefer playbooks + profiles after field work; keep
+drivers boring and experiments in policies.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ With signal states:
                     [2: SB Left (R)]  [5: SB Thru (R)]
 ```
 
+## NTCIP Manager Scaffold
+
+Three-layer NTCIP architecture (Manager-side GET/SET) lives under `src/ntcip/`:
+
+1. **Protocol Engine** (`ntcip.protocol`) -- async SNMP via pluggable backend (pysnmp seam + stub)
+2. **Object & MIB** (`ntcip.mib`) -- OID registry, ASN.1 types, NTCIP DateAndTime
+3. **Business Logic** (`ntcip.business`) -- `NtcipManager` facade and adapters
+
+```bash
+# Offline demo: async GET of ASC phase status (stub backend)
+PYTHONPATH=src python -m ntcip
+
+# NTCIP unit tests (verbose)
+make test-ntcip
+```
+
+See `docs/ntcip_architecture.md` for layering details and standard references.
+
 ## Contributing
 
 See `CONTRIBUTING.md`

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,63 @@
+# START HERE -- ITS Systems Lab
+
+You are looking at a **personal Intelligent Transportation Systems (ITS) lab**:
+a place to learn standards, replicate field systems, and innovate safely.
+
+If you are returning after time away, read in this order:
+
+1. This file (5 minutes)
+2. [`docs/ITS_LAB_STRATEGY.md`](docs/ITS_LAB_STRATEGY.md) -- mission, domains, rules
+3. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) -- locked platform seams
+4. [`docs/ntcip_architecture.md`](docs/ntcip_architecture.md) -- NTCIP vertical (signals first)
+5. [`docs/ROADMAP.md`](docs/ROADMAP.md) -- what to do next
+
+## What this repo is (and is not)
+
+| Is | Is not |
+|----|--------|
+| Multi-domain ITS workbench (VMS, RWIS, CCTV, signals, data stations, tunnel, airport sandbox) | A single-vendor ATMS product |
+| Standards-true drivers + device profiles | A place for prod secrets / badge data |
+| Shadow-first experimentation | Unsupervised write access to field devices |
+
+## One promotion path (always)
+
+```
+capture -> model -> simulate -> shadow -> field
+```
+
+Never skip straight from idea to SET/write on a live device.
+
+## Where code lives
+
+| Path | Purpose |
+|------|---------|
+| `src/its/` | Shared platform: profiles, adapter protocols, policies, shadow log |
+| `src/ntcip/` | NTCIP Manager stack (Layer 1-3); first vertical = ASC signals |
+| `src/cli/` | Existing signal layout / sim CLI |
+| `profiles/` | Sanitized device/site packs (replicate field reality) |
+| `captures/` | Anonymized protocol traces for tests and learning |
+| `playbooks/` | Ops-language how-tos you wrote after real work |
+| `domains/` | Per-asset notes and adapter stubs (vms, rwis, cctv, ...) |
+| `policies/` | Experiments and algorithms (fast-moving) |
+| `airport_lab/` | Sandbox-only learning for airport security concepts |
+| `mibs/` | NTCIP SMI modules (revision-pinned) |
+
+## Quick commands
+
+```bash
+# NTCIP Manager demo (stub ASC phase status)
+PYTHONPATH=src python -m ntcip
+
+# Signal layout / cycle sim (existing)
+python src/cli/main.py layout --states
+
+# Platform + NTCIP tests
+PYTHONPATH=src python -m pytest -v tests/its tests/ntcip
+```
+
+## Returning after a field touch?
+
+1. Add or update a file under `playbooks/`
+2. Add or update a sanitized entry under `profiles/`
+3. If you captured traffic, drop an anonymized fixture in `captures/`
+4. Only then open `policies/` for an experiment

--- a/airport_lab/README.md
+++ b/airport_lab/README.md
@@ -1,0 +1,26 @@
+# Airport Lab (Sandbox Only)
+
+Adjacent learning space for **airport systems** (security, video, access
+concepts). This is intentionally isolated from roadway ITS write paths.
+
+## Hard rules
+
+1. Synthetic identities and mock APIs only
+2. No production PACS/VMS credentials, badge data, or live camera URLs
+3. No "shadowing" live airport security controls without written authority
+4. Prefer architecture notes and workflow drills over integrations
+
+## Suggested learning modules (create as you go)
+
+| Module | Content |
+|--------|---------|
+| `notes/video_architecture.md` | How airport video relates to roadway CCTV/ONVIF skills |
+| `notes/access_control_concepts.md` | Zones, badges, anti-passback (conceptual) |
+| `mocks/` | Fake event JSON for door / alarm / camera workflows |
+| `drills/` | Tabletop scripts (lost badge, camera offline) |
+
+## Bridge from roadway ITS
+
+Skills that transfer: CCTV presets/verify, event timelines, multi-system
+playbooks, shadow-before-act discipline. Protocols and governance differ --
+do not assume NTCIP patterns apply.

--- a/captures/README.md
+++ b/captures/README.md
@@ -1,0 +1,19 @@
+# Captures
+
+Anonymized protocol or API traces used to **regress and learn** field behavior.
+
+## Rules
+
+- Strip credentials, public IPs of real devices if policy requires, and PII
+- Prefer documentation-range addresses in redacted fixtures
+- Name files: `<domain>_<sitecode>_<scenario>.json`
+- Link each capture from a playbook when possible
+
+## Suggested contents per file
+
+- timestamp (UTC)
+- profile_id
+- request/response pairs (OIDs or API paths)
+- expected domain snapshot after decode
+
+Empty until you add your first field capture -- that is intentional.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,142 @@
+# Platform Architecture (Locked Seams)
+
+This document freezes the **high-value shapes** of the ITS lab.
+Implementations may grow; these seams should stay stable.
+
+## System context
+
+```
++------------------------------------------------------------------+
+|  Playbooks / CLI / GIS / future Northbound API                   |
++-----------------------------+------------------------------------+
+                              | intents (domain language)
++-----------------------------v------------------------------------+
+|  Policies (experiments)     |  shadow logger (observe/recommend) |
++-----------------------------+------------------------------------+
+                              |
++-----------------------------v------------------------------------+
+|  Domain adapters                                                 |
+|  signals | vms | rwis | cctv | data_station | tunnel | airport   |
++-----------------------------+------------------------------------+
+                              |
++-----------------------------v------------------------------------+
+|  Protocol drivers                                                |
+|  NTCIP (src/ntcip) | ONVIF/stub | HTTP/TMDD stub | other         |
++-----------------------------+------------------------------------+
+                              |
++-----------------------------v------------------------------------+
+|  Device profiles + captures + MIB/API metadata                   |
++------------------------------------------------------------------+
+```
+
+## Package responsibilities
+
+### `src/its/` -- shared platform (domain-agnostic)
+
+| Module | Responsibility |
+|--------|----------------|
+| `profile.py` | `DeviceProfile` -- sanitized site/device pack model |
+| `adapters.py` | `DomainAdapter` protocol -- read/status/act seams |
+| `policies/base.py` | `Policy` protocol -- evaluate observations -> recommendations |
+| `shadow.py` | `ShadowBus` -- record would-be actions without executing |
+| `events.py` | Common event types for logging and replay |
+| `registry.py` | In-process registry of adapters by domain + profile id |
+
+### `src/ntcip/` -- NTCIP vertical (Manager-first)
+
+Three layers (do not collapse):
+
+1. **Protocol** -- `SnmpEngine` / `SnmpBackend` (async UDP, timeouts, auth errors)
+2. **MIB / objects** -- `MibRegistry`, codecs (DateAndTime), OID -> domain
+3. **Business** -- `NtcipManager` + adapters (`get_phase_status`, timing plan)
+
+Signals (ASC 1202) are the first concrete vertical. VMS (1203), ESS/RWIS (1204),
+and CCTV (1205) should reuse Layers 1-2 and add Layer 3 adapters -- not fork
+the stack.
+
+### Existing signal sim / GIS
+
+`src/cli/`, layout engine, and map tooling remain the **proving ground** for
+signal ideas. Prefer consuming `NtcipManager` / `DomainAdapter` snapshots over
+duplicating phase logic in the UI.
+
+## Core types (contracts)
+
+### DeviceProfile
+
+Minimal fields every profile must support:
+
+- `profile_id`, `domain`, `display_name`
+- `protocol` (`ntcip`, `onvif`, `http`, `mqtt`, `mock`)
+- `endpoint` (host/URL pattern; no secrets)
+- `identity` (unit id, site code, corridor)
+- `capabilities` (list of supported intents)
+- `mib_or_api_revision` (string pin)
+- `notes` / `quirks`
+
+Stored as YAML/JSON under `profiles/`. Loaded into `DeviceProfile`.
+
+### DomainAdapter
+
+```text
+async def probe(profile) -> Health
+async def get_status(profile) -> DomainStatus
+async def recommend(profile, intent) -> Recommendation   # no side effects
+async def apply(profile, intent, *, dry_run=True) -> Result
+```
+
+Default `dry_run=True`. Live writes require explicit opt-in at the call site.
+
+### Policy
+
+```text
+async def observe(adapter, profile) -> Observation
+async def evaluate(observation) -> list[Recommendation]
+```
+
+Policies never open sockets directly; they only use adapters.
+
+### ShadowBus
+
+Append-only recommendations:
+
+- timestamp, profile_id, policy_id, intent, reason, payload
+- used for ops review and regression fixtures
+
+## Domain expansion pattern (copy this)
+
+When adding VMS / RWIS / CCTV:
+
+1. Add `domains/<name>/README.md` (standards, intents, safety notes)
+2. Add `profiles/examples/<name>_demo.yaml`
+3. Implement `src/its/domains/<name>_adapter.py` (stub first)
+4. If NTCIP: add MIB object module under `src/ntcip/mib/objects/`
+5. Add playbook + one test that uses the stub
+6. Register adapter in the ITS registry
+
+## Safety boundaries
+
+| Zone | Allowed |
+|------|---------|
+| `profiles/`, `captures/`, `playbooks/` | Sanitized only |
+| `src/its`, `src/ntcip` | No hardcoded credentials |
+| `airport_lab/` | Synthetic identities and fake APIs only |
+| Live write paths | Behind `dry_run=False` + explicit credentials from env |
+
+## What must not happen
+
+- Business/policy code importing pysnmp or ONVIF client types directly
+- OIDs copied into CLI scripts outside Layer 2/3 adapters
+- Airport or PACS credentials committed to the repo
+- Collapsing NTCIP layers "for speed" in feature branches that merge to main
+
+## Test strategy
+
+| Layer | Test style |
+|-------|------------|
+| Platform contracts | Unit tests on profile load, shadow bus, policy evaluate |
+| NTCIP | Stub backend + DateAndTime / registry / manager tests |
+| Domains | Adapter stub tests per domain |
+| Captures | Replay fixtures (later) against stub drivers |
+
+See `tests/its/` and `tests/ntcip/`.

--- a/docs/ITS_LAB_STRATEGY.md
+++ b/docs/ITS_LAB_STRATEGY.md
@@ -1,0 +1,114 @@
+# ITS Systems Lab Strategy
+
+**Audience:** Future you (transportation / ITS engineer).  
+**Purpose:** Learn, grow, and innovate across roadway ITS, tunnel ITS, and
+adjacent domains (airport security sandbox) without losing field fidelity.
+
+## Mission
+
+Build a **digital twin + interchange kit** for the systems you operate:
+
+- Faithful enough to **replicate** cabinets, signs, sensors, and cameras you meet
+- Flexible enough to **host new ideas** behind stable intents (shadow-first)
+- Broad enough for **CCTV, data stations, RWIS, VMS, signals, tunnels**,
+  with a walled **airport_lab** for security learning
+
+Positioning line:
+
+> A standards-true ITS workbench that can mirror field implementations and
+> host experimental workflows behind the same interfaces agencies already trust.
+
+## Your domain map
+
+| Domain | Typical protocols / standards | Lab priority |
+|--------|-------------------------------|--------------|
+| VMS / DMS | NTCIP 1203, MULTI | High -- common ops surface |
+| RWIS / ESS | NTCIP 1204 | High -- weather-responsive ops |
+| CCTV | NTCIP 1205 and/or ONVIF/RTSP | High -- roadway + tunnel + airport bridge |
+| Signals / ASC | NTCIP 1201 / 1202 | Active vertical (scaffold exists) |
+| Data stations | TMDD, agency APIs, sometimes NTCIP | Medium -- performance measures |
+| Tunnel ITS | ITS + SCADA scenario orchestration | Medium -- crossover playbooks |
+| Airport security | PACS / video / SOP (sandbox only) | Low until formal authority; mocks only |
+
+## Two tracks, one core
+
+### Track A -- Replicate (earn ops trust)
+
+Goal: clone existing implementations as data + tests.
+
+Artifacts:
+
+- **Device profile packs** in `profiles/` (vendor, firmware, protocol, objects/API, quirks)
+- **Captures** in `captures/` (anonymized GET/SET/trap or API traces)
+- **Playbooks** in `playbooks/` (ops language: patch VMS, sync time, verify camera)
+- **Conformance as data** (what is RO vs RW; which objects exist)
+
+### Track B -- Innovate (ship ideas safely)
+
+Goal: try new engineering ideas without rewriting field stacks.
+
+Artifacts:
+
+- **Policies** in `policies/` / `src/its/policies/` implementing a small interface
+- **Shadow mode** -- read live (or replay), log "would have done X", no write
+- **Sim / GIS** -- prove spatial and timing impact before staging
+- **Agent SIL** (later) -- local sim answers as if it were a field device
+
+Creativity lives in policies and playbooks. Drivers and profiles stay boring.
+
+## Architecture principles (non-negotiable)
+
+1. **Stable core, volatile edges** -- protocol drivers and profiles change slowly;
+   policies and playbooks change fast.
+2. **Intents over raw protocol** -- business code says `post_vms_message` or
+   `get_phase_status`, never scatters OIDs/URLs.
+3. **Pluggable drivers** -- NTCIP, ONVIF, HTTP/TMDD, MQTT stubs share the same
+   adapter shape (`DomainAdapter`).
+4. **Shadow before write** -- every new policy defaults to observe/recommend.
+5. **No secrets in git** -- communities, USM keys, badge data, prod URLs stay
+   in local env / secret store. Profiles are sanitized.
+6. **Airport isolation** -- `airport_lab/` is synthetic only until explicit
+   authority exists. No prod security integrations by default.
+
+## Promotion path
+
+```
+capture  ->  model  ->  simulate  ->  shadow  ->  field
+ (trace)    (profile)   (sim/GIS)   (recommend)  (ops-approved write)
+```
+
+Gate questions:
+
+| Gate | Question |
+|------|----------|
+| capture | Do we have a real (sanitized) example of behavior? |
+| model | Is there a profile + typed intent for this asset? |
+| simulate | Does the idea work offline against stub/sim? |
+| shadow | Would ops accept the recommendation log? |
+| field | Is there explicit write approval and rollback? |
+
+## Weekly habit (growth loop)
+
+After any field touch:
+
+1. Half-page playbook in `playbooks/`
+2. Profile stub update in `profiles/`
+3. Optional anonymized capture in `captures/`
+4. Failing or characterizing test if behavior surprised you
+5. Only then a policy experiment
+
+## Success criteria (when you return)
+
+You can:
+
+- [ ] Point a new engineer at `START_HERE.md` and they find the mission in 5 minutes
+- [ ] Add a VMS or RWIS read path without rewriting the NTCIP ASC stack
+- [ ] Drop a sanitized profile for a site you visited this month
+- [ ] Run a policy in shadow mode and get a recommendation log
+- [ ] Keep airport learning inside `airport_lab/` with zero prod credentials
+
+## Related docs
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) -- platform seams to keep stable
+- [`ROADMAP.md`](ROADMAP.md) -- ordered next steps
+- [`ntcip_architecture.md`](ntcip_architecture.md) -- NTCIP layered stack detail

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,51 @@
+# Roadmap -- Next Steps
+
+Ordered for a working ITS engineer: maximize learning per hour, keep field risk low.
+
+## Now (foundation -- largely in place)
+
+- [x] NTCIP layered Manager scaffold (`src/ntcip/`)
+- [x] ASC phase status demo + DateAndTime codec
+- [x] Shared ITS platform seams (`src/its/`)
+- [x] Strategy docs (`START_HERE.md`, this roadmap)
+- [x] Example profile + playbooks + domain stubs
+
+## Next (high value)
+
+1. **Second NTCIP domain (pick one you touch most): VMS or RWIS**
+   - Stub adapter + demo profile
+   - One real read playbook from your work
+   - Optional: snmpsim fixture
+
+2. **Wire `PysnmpBackend`**
+   - Real GET/SET against snmpsim, then staging
+   - Config via env: host, community/USM, timeout
+
+3. **Shadow workflow end-to-end**
+   - One policy that reads ASC (or VMS) status and logs a recommendation
+   - CLI: `python -m its.shadow_demo`
+
+4. **CCTV adapter seam**
+   - ONVIF or vendor stub: list presets / get status
+   - Enables tunnel verify + future airport video learning
+
+## Then (replicate at scale)
+
+5. Profile pack for a real corridor (sanitized)
+6. Capture library + replay tests
+7. Conformance flags on profiles (RO/RW object lists)
+8. Timing / VMS message transactional SET path (NTCIP DB transactions where required)
+
+## Later (innovate + crossover)
+
+9. Hook GIS / layout CLI to live or stub adapter snapshots
+10. Tunnel scenario playbooks (CCTV + VMS + data station)
+11. Agent SIL for signal sim
+12. `airport_lab` mock access-control + video workflow (synthetic only)
+
+## Explicit non-goals (for now)
+
+- Building a full ATMS UI
+- Supporting every vendor MIB on day one
+- Autonomous field writes
+- Production airport security integration

--- a/docs/ntcip_architecture.md
+++ b/docs/ntcip_architecture.md
@@ -1,0 +1,55 @@
+# NTCIP Stack Architecture
+
+## Tech choices (scaffold defaults)
+
+| Concern | Choice |
+|---------|--------|
+| Language | Python 3.9+ |
+| Concurrency | `asyncio` (non-blocking UDP I/O) |
+| Preferred SNMP library | **pysnmp** (pluggable via `SnmpBackend`) |
+| Demo / tests | `StubSnmpBackend` (no live cabinet required) |
+
+Placeholders in the original brief were filled to match this repository's
+existing Python traffic-signal toolchain.
+
+## Layers
+
+```
++------------------------------------------------------+
+| Layer 3: Business Logic Adapter                      |
+|   NtcipManager, PhaseStatusAdapter, intents          |
++---------------------------+--------------------------+
+                            | typed domain objects
++---------------------------v--------------------------+
+| Layer 2: NTCIP Object & MIB                          |
+|   MibRegistry, MibObjectMapper, DateAndTime, OIDs    |
++---------------------------+--------------------------+
+                            | SnmpVarBind / OIDs
++---------------------------v--------------------------+
+| Layer 1: Protocol Engine                             |
+|   SnmpEngine / AsyncSnmpEngine -> SnmpBackend        |
+|   (pysnmp | stub | future Net-SNMP)                  |
++------------------------------------------------------+
+```
+
+## Roles
+
+- **Manager (Central System)** -- implemented by `NtcipManager` (GET/SET focus).
+- **Agent (Field Device)** -- same Layer 1/2; future facade can expose Agent MIB.
+
+## Standards referenced
+
+- NTCIP 1103 -- Transportation Management Protocols
+- NTCIP 1201 -- Global Object Definitions (`unitID`, `unitLocation`, DateAndTime)
+- NTCIP 1202 -- ASC (`phaseStatusGroupGreens`, etc.)
+- NTCIP 8004 -- Structure and Identification of Management Information
+
+## Quick start
+
+```bash
+# Demo (stub backend)
+PYTHONPATH=src python -m ntcip
+
+# Tests
+PYTHONPATH=src pytest -v tests/ntcip
+```

--- a/docs/ntcip_architecture.md
+++ b/docs/ntcip_architecture.md
@@ -1,5 +1,9 @@
 # NTCIP Stack Architecture
 
+> Broader lab mission: see [`ITS_LAB_STRATEGY.md`](ITS_LAB_STRATEGY.md) and
+> [`ARCHITECTURE.md`](ARCHITECTURE.md). NTCIP is the first protocol vertical
+> inside the multi-domain ITS lab (`src/its/` + `src/ntcip/`).
+
 ## Tech choices (scaffold defaults)
 
 | Concern | Choice |

--- a/domains/README.md
+++ b/domains/README.md
@@ -1,0 +1,4 @@
+# Domains
+
+Human-facing notes per asset class. Code adapters live in `src/its/domains/`;
+this tree holds standards context and expansion checklists.

--- a/domains/cctv/README.md
+++ b/domains/cctv/README.md
@@ -1,0 +1,18 @@
+# Domain: CCTV
+
+- **Standards:** NTCIP 1205 and/or ONVIF / RTSP (vendor-specific)
+- **Adapter:** `its.domains.cctv_adapter.CctvStubAdapter` (stub)
+- **Demo profile:** `profiles/examples/cctv_demo.json`
+
+## Intents
+
+| Intent | Mode |
+|--------|------|
+| get_status | read |
+| goto_preset | write (dry-run default) |
+
+## Expand next
+
+- ONVIF client behind the adapter
+- Tunnel verify playbook (preset + incident note)
+- Do not store real RTSP credentials in git

--- a/domains/data_stations/README.md
+++ b/domains/data_stations/README.md
@@ -1,0 +1,17 @@
+# Domain: Data stations
+
+- **Typical interfaces:** TMDD, agency archive APIs, sometimes NTCIP
+- **Adapter:** not scaffolded yet -- add `DataStationStubAdapter` when you
+  have a feed you can sanitize
+
+## Intents (planned)
+
+| Intent | Mode |
+|--------|------|
+| get_volume_speed | read |
+| get_station_metadata | read |
+
+## Expand next
+
+- One JSON capture of a station metadata response
+- Performance-measure notebook under `notebooks/` linked from a playbook

--- a/domains/rwis/README.md
+++ b/domains/rwis/README.md
@@ -1,0 +1,17 @@
+# Domain: RWIS / ESS
+
+- **Standards:** NTCIP 1204
+- **Adapter:** `its.domains.rwis_adapter.RwisStubAdapter` (stub)
+- **Demo profile:** `profiles/examples/rwis_demo.json`
+
+## Intents
+
+| Intent | Mode |
+|--------|------|
+| get_status | read |
+| raise_weather_alert | recommend / limited write |
+
+## Expand next
+
+- Observation quality flags
+- Cross-domain policy: RWIS -> VMS recommendation

--- a/domains/signals/README.md
+++ b/domains/signals/README.md
@@ -1,0 +1,20 @@
+# Domain: Signals (ASC)
+
+- **Standards:** NTCIP 1201 (global), NTCIP 1202 (ASC)
+- **Adapter:** `its.domains.signals_adapter.SignalsNtcipAdapter`
+- **Stack:** `src/ntcip/` Layers 1-3
+- **Demo profile:** `profiles/examples/signals_demo.json`
+
+## Intents
+
+| Intent | Mode |
+|--------|------|
+| get_phase_status | read |
+| get_unit_identity | read |
+| set_timing_plan | write (dry-run default) |
+
+## Expand next
+
+- Pattern/split tables with DB transactions
+- Detector status
+- Hook `src/cli` layout states to adapter snapshots

--- a/domains/tunnel/README.md
+++ b/domains/tunnel/README.md
@@ -1,0 +1,16 @@
+# Domain: Tunnel ITS (crossover)
+
+Tunnel systems combine roadway ITS (CCTV, VMS, data stations, often signals /
+lane control) with facility / SCADA concerns.
+
+## Lab approach
+
+- Reuse CCTV + VMS + RWIS adapters
+- Encode **scenarios** as playbooks (congestion, air quality, fire response
+  coordination) -- not as a separate protocol stack on day one
+- Keep SCADA credentials and safety PLCs out of this repo unless you build an
+  explicit sanitized mock
+
+## First playbook to write
+
+"Verify portal camera + confirm VMS message during drill" using dry-run only.

--- a/domains/vms/README.md
+++ b/domains/vms/README.md
@@ -1,0 +1,18 @@
+# Domain: VMS / DMS
+
+- **Standards:** NTCIP 1203, MULTI markup
+- **Adapter:** `its.domains.vms_adapter.VmsStubAdapter` (stub)
+- **Demo profile:** `profiles/examples/vms_demo.json`
+
+## Intents
+
+| Intent | Mode |
+|--------|------|
+| get_status | read |
+| post_message | write (dry-run default) |
+
+## Expand next
+
+- MULTI validate + font table awareness
+- NTCIP 1203 object module under `src/ntcip/mib/objects/`
+- Message library as data (agency-approved)

--- a/mibs/NTCIP1201-GLOBAL.snippet.mib
+++ b/mibs/NTCIP1201-GLOBAL.snippet.mib
@@ -1,0 +1,22 @@
+-- NTCIP 1201 Global Objects (illustrative snippet for scaffold docs)
+-- NOT a complete / normative MIB. Align with your certified module.
+--
+-- NEMA enterprise: 1.3.6.1.4.1.1206
+-- profiles.global: 1.3.6.1.4.1.1206.4.2.6
+
+UNIT-ID OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Unique identification of the field unit."
+    ::= { unit 3 }
+
+UNIT-LOCATION OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Location description of the field unit."
+    ::= { unit 7 }
+
+-- DateAndTime ::= OCTET STRING (SIZE (8))
+-- YYYY(2) MM DD HH MM SS deci-second

--- a/mibs/NTCIP1202-ASC.snippet.mib
+++ b/mibs/NTCIP1202-ASC.snippet.mib
@@ -1,0 +1,13 @@
+-- NTCIP 1202 ASC Objects (illustrative snippet for scaffold docs)
+-- NOT a complete / normative MIB. Align with your certified module.
+--
+-- profiles.asc: 1.3.6.1.4.1.1206.4.2.1
+-- phaseStatusGroupGreens ::= { phaseStatusGroupEntry 4 }
+
+PHASE-STATUS-GROUP-GREENS OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Bit field of phases currently in Green. Bit 0 = phase 1."
+    ::= { phaseStatusGroupEntry 4 }

--- a/mibs/README.md
+++ b/mibs/README.md
@@ -1,0 +1,17 @@
+# NTCIP MIB Modules
+
+Place compiled or source SMI MIB modules here for the Object & MIB layer.
+
+## Expected modules (scaffold)
+
+| File | Standard | Purpose |
+|------|----------|---------|
+| `NEMA-MIB` / enterprise root | NTCIP 8004 | `1.3.6.1.4.1.1206` |
+| `NTCIP1201-MIB` | NTCIP 1201 | Global objects (`unitID`, `unitLocation`, DateAndTime) |
+| `NTCIP1202-MIB` | NTCIP 1202 | ASC phase / pattern / detector objects |
+
+## Notes
+
+- The Python registry under `src/ntcip/mib/objects/` ships a **minimal** subset for development.
+- Production deployments should load vendor-certified MIB revisions that match the field firmware.
+- Do not commit proprietary vendor MIB text if your license forbids redistribution.

--- a/playbooks/01_clone_signal_status.md
+++ b/playbooks/01_clone_signal_status.md
@@ -1,0 +1,49 @@
+# Playbook: Clone signal phase status
+
+- **Domain:** signals
+- **Profile:** `profiles/examples/signals_demo.json`
+- **Last field touch:** lab scaffold
+- **Risk:** read-only
+
+## Goal
+
+Read ASC red/yellow/green status groups through the ITS adapter and NTCIP Manager
+(stub backend offline; same path later against a real cabinet).
+
+## Preconditions
+
+- Repo checked out; `PYTHONPATH=src`
+- Demo profile present
+
+## Steps
+
+```bash
+# Platform shadow demo (policy + adapter)
+PYTHONPATH=src python -m its
+
+# Direct NTCIP Manager demo
+PYTHONPATH=src python -m ntcip
+
+# Signal layout view (existing sim CLI)
+python src/cli/main.py layout --states
+```
+
+## Expected result
+
+- Green phases `[2, 5]` from stub data
+- Unit identity `ASC-DEMO-001` at Main St & 1st Ave
+- Shadow demo may emit `operator_verify_intersection` if expected greens differ
+
+## Captures / tests
+
+- `tests/ntcip/business/test_manager.py`
+- `tests/its/test_signals_adapter.py`
+
+## Gotchas
+
+- Do not hardcode OIDs in scripts; use `NtcipManager` / `SignalsNtcipAdapter`
+- Live SNMP requires implementing `PysnmpBackend` and env-based credentials
+
+## Next innovation idea (optional)
+
+- Policy that compares stub/live greens to time-of-day plan expectations

--- a/playbooks/02_vms_message_shadow.md
+++ b/playbooks/02_vms_message_shadow.md
@@ -1,0 +1,41 @@
+# Playbook: VMS message in shadow mode
+
+- **Domain:** vms
+- **Profile:** `profiles/examples/vms_demo.json`
+- **Risk:** shadow / dry-run
+
+## Goal
+
+Practice traveler-information messaging without touching a sign.
+
+## Steps (Python sketch)
+
+```python
+import asyncio
+from pathlib import Path
+from its.profile import load_device_profile
+from its.domains.vms_adapter import VmsStubAdapter
+from its.shadow import ShadowBus
+
+async def main():
+    profile = load_device_profile(Path("profiles/examples/vms_demo.json"))
+    adapter = VmsStubAdapter()
+    shadow = ShadowBus()
+    status = await adapter.get_status(profile)
+    print(status.summary)
+    rec = await adapter.recommend(profile, "post_message", message="ICE AHEAD")
+    shadow.record(rec)
+    result = await adapter.apply(profile, "post_message", message="ICE AHEAD", dry_run=True)
+    print(result)
+
+asyncio.run(main())
+```
+
+## Expected result
+
+Dry-run apply succeeds; stub message unchanged unless `dry_run=False` (still in-memory only).
+
+## Gotchas
+
+- Real DMS needs NTCIP 1203 MULTI encoding and often font/graphics checks
+- Never commit real message libraries that contain sensitive detour details if agency policy forbids it

--- a/playbooks/03_rwis_weather_check.md
+++ b/playbooks/03_rwis_weather_check.md
@@ -1,0 +1,31 @@
+# Playbook: RWIS weather check
+
+- **Domain:** rwis
+- **Profile:** `profiles/examples/rwis_demo.json`
+- **Risk:** read-only
+
+## Goal
+
+Pull ESS-style observations through the stub adapter as a template for
+weather-responsive ops playbooks.
+
+## Steps (Python sketch)
+
+```python
+import asyncio
+from pathlib import Path
+from its.profile import load_device_profile
+from its.domains.rwis_adapter import RwisStubAdapter
+
+async def main():
+    profile = load_device_profile(Path("profiles/examples/rwis_demo.json"))
+    status = await RwisStubAdapter().get_status(profile)
+    print(status.summary, status.data)
+
+asyncio.run(main())
+```
+
+## Next innovation idea
+
+- Policy: if `surface_temp_c` below threshold, shadow-recommend a VMS message
+  via the VMS adapter (cross-domain orchestration)

--- a/playbooks/04_after_field_touch.md
+++ b/playbooks/04_after_field_touch.md
@@ -1,0 +1,23 @@
+# Playbook: After any field touch
+
+- **Domain:** meta
+- **Risk:** n/a
+
+## Goal
+
+Turn every site visit or ticket into durable lab assets (learn / grow loop).
+
+## Steps
+
+1. Create or update `playbooks/<nn>_<short_name>.md` from `_template.md`
+2. Add or edit a sanitized profile under `profiles/`
+3. If you captured traffic or screenshots of MIB walks, redact and store under `captures/`
+4. Note quirks (vendor firmware bugs, RO objects, weird MULTI limits)
+5. Only then open `src/its/policies/` for an experiment
+6. Run tests: `PYTHONPATH=src python -m pytest -v tests/its tests/ntcip`
+
+## Definition of done
+
+- Future You can replay the read path offline
+- No secrets landed in git
+- At least one sentence on what you would innovate next

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,17 @@
+# Playbooks
+
+Ops-language runbooks written after real work. These are how Future You
+remembers *what to do*, while `profiles/` remembers *what the device is*.
+
+## Template
+
+Copy `_template.md` for each new playbook.
+
+## Index
+
+| Playbook | Domain | Purpose |
+|----------|--------|---------|
+| `01_clone_signal_status.md` | signals | Read ASC phase status via lab stack |
+| `02_vms_message_shadow.md` | vms | Draft a VMS message in shadow/dry-run |
+| `03_rwis_weather_check.md` | rwis | Pull ESS stub observations |
+| `04_after_field_touch.md` | meta | Habit loop after any field visit |

--- a/playbooks/_template.md
+++ b/playbooks/_template.md
@@ -1,0 +1,36 @@
+# Playbook: <title>
+
+- **Domain:** 
+- **Profile:** `profiles/...`
+- **Last field touch:** YYYY-MM-DD
+- **Risk:** read-only | shadow | write (ops-approved)
+
+## Goal
+
+One sentence.
+
+## Preconditions
+
+- Access / VPN / staging notes (no secrets)
+- Profile exists and capabilities listed
+
+## Steps
+
+1. 
+2. 
+3. 
+
+## Expected result
+
+## Captures / tests
+
+- `captures/...` (if any)
+- `tests/...` (if any)
+
+## Gotchas
+
+- 
+
+## Next innovation idea (optional)
+
+- 

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,15 @@
+# Policies (experiments)
+
+Fast-moving ideas. Implementations preferred under `src/its/policies/` so
+they are importable and tested.
+
+| Policy | Purpose |
+|--------|---------|
+| `phase_green_monitor` | Flag unexpected ASC greens (shadow recommend) |
+
+New policy checklist:
+
+1. Implement `Policy` protocol
+2. Unit test with stub adapter
+3. Default path records to `ShadowBus` only
+4. Document in a playbook before any dry_run=False usage

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,24 @@
+# Device Profiles
+
+Sanitized packs that describe real (or lab) assets so you can **replicate**
+field reality without committing secrets.
+
+## Rules
+
+- No community strings, passwords, USM keys, badge IDs, or prod API tokens
+- Prefer site codes and RFC 5737 documentation IPs (`192.0.2.0/24`)
+- Pin `mib_or_api_revision` when known
+- One file per device or logical site asset
+
+## Layout
+
+```
+profiles/
+  examples/           # committed demos
+  <corridor_or_agency>/   # your sanitized packs (local or committed)
+```
+
+## Schema (JSON or YAML)
+
+See `examples/signals_demo.json` for the canonical fields consumed by
+`its.profile.DeviceProfile`.

--- a/profiles/examples/cctv_demo.json
+++ b/profiles/examples/cctv_demo.json
@@ -1,0 +1,17 @@
+{
+  "profile_id": "demo.cctv.tunnel-portal",
+  "domain": "cctv",
+  "display_name": "Tunnel Portal Camera (demo)",
+  "protocol": "onvif",
+  "endpoint": "192.0.2.40",
+  "identity": "CAM-DEMO-040",
+  "capabilities": ["get_status", "goto_preset"],
+  "mib_or_api_revision": "ONVIF-stub",
+  "notes": "Bridge profile for roadway/tunnel video; airport_lab may mirror this pattern with synthetic data only.",
+  "quirks": [
+    "Stub presets only; no RTSP URLs committed"
+  ],
+  "metadata": {
+    "standards": ["NTCIP 1205", "ONVIF"]
+  }
+}

--- a/profiles/examples/rwis_demo.json
+++ b/profiles/examples/rwis_demo.json
@@ -1,0 +1,15 @@
+{
+  "profile_id": "demo.rwis.pass-summit",
+  "domain": "rwis",
+  "display_name": "Pass Summit ESS (demo)",
+  "protocol": "ntcip",
+  "endpoint": "192.0.2.30",
+  "identity": "RWIS-DEMO-030",
+  "capabilities": ["get_status", "raise_weather_alert"],
+  "mib_or_api_revision": "NTCIP-1204-pending",
+  "notes": "Stub ESS observations for weather-responsive playbooks.",
+  "quirks": [],
+  "metadata": {
+    "standard": "NTCIP 1204"
+  }
+}

--- a/profiles/examples/signals_demo.json
+++ b/profiles/examples/signals_demo.json
@@ -1,0 +1,22 @@
+{
+  "profile_id": "demo.signals.main-1st",
+  "domain": "signals",
+  "display_name": "Main St & 1st Ave ASC (demo)",
+  "protocol": "ntcip",
+  "endpoint": "192.0.2.10",
+  "identity": "ASC-DEMO-001",
+  "capabilities": [
+    "get_phase_status",
+    "get_unit_identity",
+    "set_timing_plan"
+  ],
+  "mib_or_api_revision": "NTCIP-1202-scaffold",
+  "notes": "Stub-backed demo profile for NtcipManager / SignalsNtcipAdapter.",
+  "quirks": [
+    "Uses StubSnmpBackend unless PysnmpBackend is wired"
+  ],
+  "metadata": {
+    "corridor": "demo-arterial",
+    "neuma_phases": 8
+  }
+}

--- a/profiles/examples/vms_demo.json
+++ b/profiles/examples/vms_demo.json
@@ -1,0 +1,15 @@
+{
+  "profile_id": "demo.vms.sb-approach",
+  "domain": "vms",
+  "display_name": "SB Approach DMS (demo)",
+  "protocol": "ntcip",
+  "endpoint": "192.0.2.20",
+  "identity": "VMS-DEMO-020",
+  "capabilities": ["get_status", "post_message"],
+  "mib_or_api_revision": "NTCIP-1203-pending",
+  "notes": "Stub adapter only. Replace with NTCIP 1203 driver when ready.",
+  "quirks": [],
+  "metadata": {
+    "standard": "NTCIP 1203"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,22 @@ python = ">=3.9,<3.12"
 folium = "*"
 geopandas = "*"
 requests = "*"
+# Optional production SNMP backend for ntcip.protocol.backends.PysnmpBackend
+# pysnmp = ">=5.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"
+pytest-asyncio = "*"
 black = "*"
 isort = "*"
 flake8 = "*"
 mypy = "*"
 pre-commit = "*"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 folium
 geopandas
 requests
+pytest
+pytest-asyncio
+# Optional: install pysnmp to enable PysnmpBackend
+# pysnmp>=5.0.0

--- a/src/its/__init__.py
+++ b/src/its/__init__.py
@@ -1,0 +1,28 @@
+"""
+Shared ITS lab platform.
+
+Domain-agnostic seams used by signals, VMS, RWIS, CCTV, and future adapters.
+See docs/ARCHITECTURE.md and docs/ITS_LAB_STRATEGY.md.
+"""
+
+from its.adapters import DomainAdapter, DomainHealth, DomainStatus
+from its.events import Recommendation
+from its.policies.base import Observation, Policy
+from its.profile import DeviceProfile, load_device_profile
+from its.registry import AdapterRegistry
+from its.shadow import ShadowBus
+
+__all__ = [
+    "AdapterRegistry",
+    "DeviceProfile",
+    "DomainAdapter",
+    "DomainHealth",
+    "DomainStatus",
+    "Observation",
+    "Policy",
+    "Recommendation",
+    "ShadowBus",
+    "load_device_profile",
+]
+
+__version__ = "0.1.0"

--- a/src/its/__main__.py
+++ b/src/its/__main__.py
@@ -1,0 +1,72 @@
+"""
+Shadow-mode demo across the ITS platform.
+
+Run::
+
+    PYTHONPATH=src python -m its
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1]
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from its.domains.signals_adapter import SignalsNtcipAdapter  # noqa: E402
+from its.policies.phase_green_monitor import PhaseGreenMonitorPolicy  # noqa: E402
+from its.profile import load_device_profile  # noqa: E402
+from its.shadow import ShadowBus  # noqa: E402
+
+
+async def run_shadow_demo() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+    log = logging.getLogger("its.demo")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    profile_path = repo_root / "profiles" / "examples" / "signals_demo.json"
+    profile = load_device_profile(profile_path)
+
+    adapter = SignalsNtcipAdapter()
+    policy = PhaseGreenMonitorPolicy(expected_greens=(1, 6))  # deliberate mismatch
+    shadow = ShadowBus()
+
+    try:
+        health = await adapter.probe(profile)
+        log.info("probe ok=%s detail=%s", health.ok, health.detail)
+
+        observation = await policy.observe(adapter, profile)
+        log.info("status: %s", observation.status.summary)
+
+        recommendations = await policy.evaluate(observation)
+        shadow.record_many(recommendations)
+
+        if not recommendations:
+            log.info("No recommendations (observation matched policy).")
+        else:
+            for item in recommendations:
+                log.info(
+                    "RECOMMEND intent=%s reason=%s payload=%s",
+                    item.intent,
+                    item.reason,
+                    item.payload,
+                )
+        log.info("Shadow records: %s", len(shadow.records))
+        return 0
+    finally:
+        await adapter.close()
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(run_shadow_demo()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/its/adapters.py
+++ b/src/its/adapters.py
@@ -1,0 +1,76 @@
+"""
+Domain adapter contract.
+
+Each asset class (signals, VMS, RWIS, CCTV, ...) implements this shape.
+Protocol drivers (NTCIP, ONVIF, HTTP) stay behind the adapter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from its.events import Recommendation
+from its.profile import DeviceProfile
+
+
+@dataclass(frozen=True)
+class DomainHealth:
+    ok: bool
+    detail: str = ""
+    latency_ms: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class DomainStatus:
+    """Opaque-but-typed status bag returned by get_status()."""
+
+    domain: str
+    profile_id: str
+    summary: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    success: bool
+    dry_run: bool
+    detail: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class DomainAdapter(Protocol):
+    """
+    Per-domain facade used by playbooks and policies.
+
+    ``apply`` defaults to dry-run semantics at the call site; implementations
+    must refuse live writes unless ``dry_run=False`` and credentials exist.
+    """
+
+    domain: str
+
+    async def probe(self, profile: DeviceProfile) -> DomainHealth:
+        """Cheap connectivity / identity check."""
+
+    async def get_status(self, profile: DeviceProfile) -> DomainStatus:
+        """Read current operational status (no side effects)."""
+
+    async def recommend(
+        self, profile: DeviceProfile, intent: str, **params: Any
+    ) -> Recommendation:
+        """Build a recommendation for ``intent`` without executing it."""
+
+    async def apply(
+        self,
+        profile: DeviceProfile,
+        intent: str,
+        *,
+        dry_run: bool = True,
+        **params: Any,
+    ) -> ApplyResult:
+        """
+        Execute or simulate an intent.
+
+        Production callers must pass dry_run=True unless ops approved a write.
+        """

--- a/src/its/domains/__init__.py
+++ b/src/its/domains/__init__.py
@@ -1,0 +1,13 @@
+"""Concrete domain adapters (stubs grow into real drivers)."""
+
+from its.domains.cctv_adapter import CctvStubAdapter
+from its.domains.rwis_adapter import RwisStubAdapter
+from its.domains.signals_adapter import SignalsNtcipAdapter
+from its.domains.vms_adapter import VmsStubAdapter
+
+__all__ = [
+    "CctvStubAdapter",
+    "RwisStubAdapter",
+    "SignalsNtcipAdapter",
+    "VmsStubAdapter",
+]

--- a/src/its/domains/cctv_adapter.py
+++ b/src/its/domains/cctv_adapter.py
@@ -1,0 +1,72 @@
+"""CCTV stub adapter (NTCIP 1205 / ONVIF seam)."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from its.adapters import ApplyResult, DomainHealth, DomainStatus
+from its.events import Recommendation
+from its.profile import DeviceProfile
+
+
+class CctvStubAdapter:
+    """Offline camera adapter -- bridge toward tunnel and airport video labs."""
+
+    domain = "cctv"
+
+    def __init__(self, presets: List[str] | None = None) -> None:
+        self._presets = presets or ["overview", "approach_nb", "approach_sb"]
+        self._current_preset = self._presets[0]
+
+    async def probe(self, profile: DeviceProfile) -> DomainHealth:
+        return DomainHealth(ok=True, detail=f"stub cctv at {profile.endpoint}")
+
+    async def get_status(self, profile: DeviceProfile) -> DomainStatus:
+        return DomainStatus(
+            domain=self.domain,
+            profile_id=profile.profile_id,
+            summary=f"preset={self._current_preset}",
+            data={
+                "current_preset": self._current_preset,
+                "presets": list(self._presets),
+                "standards": ["NTCIP 1205", "ONVIF"],
+                "endpoint": profile.endpoint,
+            },
+        )
+
+    async def recommend(
+        self, profile: DeviceProfile, intent: str, **params: Any
+    ) -> Recommendation:
+        if intent != "goto_preset":
+            raise ValueError(f"unsupported cctv intent: {intent}")
+        preset = str(params.get("preset", self._current_preset))
+        return Recommendation(
+            intent=intent,
+            reason="Camera preset move requested for verification",
+            payload={"preset": preset},
+            profile_id=profile.profile_id,
+        )
+
+    async def apply(
+        self,
+        profile: DeviceProfile,
+        intent: str,
+        *,
+        dry_run: bool = True,
+        **params: Any,
+    ) -> ApplyResult:
+        recommendation = await self.recommend(profile, intent, **params)
+        if dry_run:
+            return ApplyResult(
+                success=True,
+                dry_run=True,
+                detail="stub dry-run; camera not moved",
+                data=recommendation.payload,
+            )
+        self._current_preset = str(recommendation.payload["preset"])
+        return ApplyResult(
+            success=True,
+            dry_run=False,
+            detail=f"stub moved to preset {self._current_preset}",
+            data=recommendation.payload,
+        )

--- a/src/its/domains/rwis_adapter.py
+++ b/src/its/domains/rwis_adapter.py
@@ -1,0 +1,74 @@
+"""RWIS / ESS stub adapter (NTCIP 1204 seam)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from its.adapters import ApplyResult, DomainHealth, DomainStatus
+from its.events import Recommendation
+from its.profile import DeviceProfile
+
+
+class RwisStubAdapter:
+    """Offline ESS/RWIS adapter with seeded weather observations."""
+
+    domain = "rwis"
+
+    def __init__(self, observations: Dict[str, Any] | None = None) -> None:
+        self._observations = observations or {
+            "air_temp_c": 4.0,
+            "surface_temp_c": 1.5,
+            "precipitation": "none",
+            "visibility_m": 2000,
+        }
+
+    async def probe(self, profile: DeviceProfile) -> DomainHealth:
+        return DomainHealth(ok=True, detail=f"stub rwis at {profile.endpoint}")
+
+    async def get_status(self, profile: DeviceProfile) -> DomainStatus:
+        return DomainStatus(
+            domain=self.domain,
+            profile_id=profile.profile_id,
+            summary=(
+                f"air={self._observations['air_temp_c']}C "
+                f"surface={self._observations['surface_temp_c']}C"
+            ),
+            data={
+                **self._observations,
+                "standard": "NTCIP 1204",
+                "endpoint": profile.endpoint,
+            },
+        )
+
+    async def recommend(
+        self, profile: DeviceProfile, intent: str, **params: Any
+    ) -> Recommendation:
+        if intent != "raise_weather_alert":
+            raise ValueError(f"unsupported rwis intent: {intent}")
+        level = str(params.get("level", "advisory"))
+        return Recommendation(
+            intent=intent,
+            reason="Weather threshold crossed (stub/policy)",
+            payload={"level": level, "observations": dict(self._observations)},
+            profile_id=profile.profile_id,
+        )
+
+    async def apply(
+        self,
+        profile: DeviceProfile,
+        intent: str,
+        *,
+        dry_run: bool = True,
+        **params: Any,
+    ) -> ApplyResult:
+        recommendation = await self.recommend(profile, intent, **params)
+        return ApplyResult(
+            success=True,
+            dry_run=dry_run,
+            detail=(
+                "stub alert recorded locally"
+                if not dry_run
+                else "stub dry-run; alert not dispatched"
+            ),
+            data=recommendation.payload,
+        )

--- a/src/its/domains/signals_adapter.py
+++ b/src/its/domains/signals_adapter.py
@@ -1,0 +1,101 @@
+"""
+Signals domain adapter -- bridges ITS platform intents to NtcipManager.
+
+This is the reference adapter showing how a real vertical plugs into
+DomainAdapter without leaking SNMP types upward.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from its.adapters import ApplyResult, DomainHealth, DomainStatus
+from its.events import Recommendation
+from its.profile import DeviceProfile
+from ntcip.business.manager import NtcipManager
+from ntcip.factory import create_ntcip_manager
+
+
+class SignalsNtcipAdapter:
+    """ASC / signal status via the NTCIP Manager facade."""
+
+    domain = "signals"
+
+    def __init__(self, manager: Optional[NtcipManager] = None) -> None:
+        self._manager = manager or create_ntcip_manager(demo_data=True)
+        self._owns_manager = manager is None
+
+    async def probe(self, profile: DeviceProfile) -> DomainHealth:
+        started = time.perf_counter()
+        identity = await self._manager.get_unit_identity(profile.endpoint)
+        latency = (time.perf_counter() - started) * 1000.0
+        ok = bool(identity.unit_id)
+        return DomainHealth(
+            ok=ok,
+            detail=f"unit_id={identity.unit_id}",
+            latency_ms=latency,
+        )
+
+    async def get_status(self, profile: DeviceProfile) -> DomainStatus:
+        snapshot = await self._manager.get_phase_status(profile.endpoint)
+        summary = (
+            f"greens={snapshot.green_phases()} "
+            f"map={snapshot.summary()}"
+        )
+        return DomainStatus(
+            domain=self.domain,
+            profile_id=profile.profile_id,
+            summary=summary,
+            data={
+                "green_phases": snapshot.green_phases(),
+                "phase_map": snapshot.summary(),
+                "host": snapshot.host,
+            },
+        )
+
+    async def recommend(
+        self, profile: DeviceProfile, intent: str, **params: Any
+    ) -> Recommendation:
+        if intent == "set_timing_plan":
+            plan = int(params.get("plan_number", 1))
+            return Recommendation(
+                intent=intent,
+                reason="Operator or policy requested timing plan change",
+                payload={"plan_number": plan, "host": profile.endpoint},
+                profile_id=profile.profile_id,
+            )
+        raise ValueError(f"unsupported signals intent: {intent}")
+
+    async def apply(
+        self,
+        profile: DeviceProfile,
+        intent: str,
+        *,
+        dry_run: bool = True,
+        **params: Any,
+    ) -> ApplyResult:
+        recommendation = await self.recommend(profile, intent, **params)
+        if dry_run:
+            return ApplyResult(
+                success=True,
+                dry_run=True,
+                detail="shadow/dry-run only; no SNMP SET sent",
+                data=recommendation.payload,
+            )
+        from ntcip.business.intents import SetSignalTimingPlan
+
+        plan = int(recommendation.payload["plan_number"])
+        await self._manager.set_signal_timing_plan(
+            SetSignalTimingPlan(host=profile.endpoint, plan_number=plan)
+        )
+        return ApplyResult(
+            success=True,
+            dry_run=False,
+            detail=f"applied timing plan {plan}",
+            data=recommendation.payload,
+        )
+
+    async def close(self) -> None:
+        if self._owns_manager:
+            await self._manager.close()

--- a/src/its/domains/vms_adapter.py
+++ b/src/its/domains/vms_adapter.py
@@ -1,0 +1,70 @@
+"""VMS / DMS stub adapter (NTCIP 1203 seam). Replace guts with real driver later."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from its.adapters import ApplyResult, DomainHealth, DomainStatus
+from its.events import Recommendation
+from its.profile import DeviceProfile
+
+
+class VmsStubAdapter:
+    """Offline VMS adapter for playbooks and policy development."""
+
+    domain = "vms"
+
+    def __init__(self, current_message: str = "ROAD WORK AHEAD") -> None:
+        self._current_message = current_message
+
+    async def probe(self, profile: DeviceProfile) -> DomainHealth:
+        return DomainHealth(ok=True, detail=f"stub vms at {profile.endpoint}")
+
+    async def get_status(self, profile: DeviceProfile) -> DomainStatus:
+        return DomainStatus(
+            domain=self.domain,
+            profile_id=profile.profile_id,
+            summary=f"message={self._current_message!r}",
+            data={
+                "message": self._current_message,
+                "standard": "NTCIP 1203",
+                "endpoint": profile.endpoint,
+            },
+        )
+
+    async def recommend(
+        self, profile: DeviceProfile, intent: str, **params: Any
+    ) -> Recommendation:
+        if intent != "post_message":
+            raise ValueError(f"unsupported vms intent: {intent}")
+        message = str(params.get("message", ""))
+        return Recommendation(
+            intent=intent,
+            reason="VMS message post requested",
+            payload={"message": message, "multi": message},
+            profile_id=profile.profile_id,
+        )
+
+    async def apply(
+        self,
+        profile: DeviceProfile,
+        intent: str,
+        *,
+        dry_run: bool = True,
+        **params: Any,
+    ) -> ApplyResult:
+        recommendation = await self.recommend(profile, intent, **params)
+        if dry_run:
+            return ApplyResult(
+                success=True,
+                dry_run=True,
+                detail="stub dry-run; message not sent to sign",
+                data=recommendation.payload,
+            )
+        self._current_message = str(recommendation.payload["message"])
+        return ApplyResult(
+            success=True,
+            dry_run=False,
+            detail="stub applied message in memory only",
+            data=recommendation.payload,
+        )

--- a/src/its/events.py
+++ b/src/its/events.py
@@ -1,0 +1,39 @@
+"""Shared event / recommendation types for adapters, policies, and shadow mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    """
+    A would-be action produced by a policy or adapter.recommend().
+
+    Shadow mode records these without executing field writes.
+    """
+
+    intent: str
+    reason: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    profile_id: str = ""
+    policy_id: str = ""
+    confidence: Optional[float] = None
+    created_at: datetime = field(default_factory=utc_now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "intent": self.intent,
+            "reason": self.reason,
+            "payload": dict(self.payload),
+            "profile_id": self.profile_id,
+            "policy_id": self.policy_id,
+            "confidence": self.confidence,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/src/its/policies/__init__.py
+++ b/src/its/policies/__init__.py
@@ -1,0 +1,10 @@
+"""Example and future experiment policies."""
+
+from its.policies.base import Observation, Policy
+from its.policies.phase_green_monitor import PhaseGreenMonitorPolicy
+
+__all__ = [
+    "Observation",
+    "PhaseGreenMonitorPolicy",
+    "Policy",
+]

--- a/src/its/policies/base.py
+++ b/src/its/policies/base.py
@@ -1,0 +1,39 @@
+"""Policy contract -- experiments evaluate observations into recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Protocol, runtime_checkable
+
+from its.adapters import DomainAdapter, DomainStatus
+from its.events import Recommendation
+from its.profile import DeviceProfile
+
+
+@dataclass(frozen=True)
+class Observation:
+    """Snapshot a policy uses as input (never a live write handle)."""
+
+    profile: DeviceProfile
+    status: DomainStatus
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Policy(Protocol):
+    """
+    Fast-moving experiment surface.
+
+    Policies must not open sockets; they only use adapters passed into
+    ``observe`` / operate on :class:`Observation` values.
+    """
+
+    policy_id: str
+
+    async def observe(
+        self, adapter: DomainAdapter, profile: DeviceProfile
+    ) -> Observation:
+        """Gather status (and optional extras) for evaluation."""
+
+    async def evaluate(self, observation: Observation) -> List[Recommendation]:
+        """Return zero or more shadow-safe recommendations."""

--- a/src/its/policies/phase_green_monitor.py
+++ b/src/its/policies/phase_green_monitor.py
@@ -1,0 +1,51 @@
+"""
+Example policy: observe ASC greens and recommend verification if unexpected.
+
+Shadow-only by design -- it never calls apply().
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from its.adapters import DomainAdapter
+from its.events import Recommendation
+from its.policies.base import Observation
+from its.profile import DeviceProfile
+
+
+class PhaseGreenMonitorPolicy:
+    """Recommend operator attention when green phases drift from expected."""
+
+    policy_id = "phase_green_monitor"
+
+    def __init__(self, expected_greens: Sequence[int] = (2, 5)) -> None:
+        self._expected = tuple(expected_greens)
+
+    async def observe(
+        self, adapter: DomainAdapter, profile: DeviceProfile
+    ) -> Observation:
+        status = await adapter.get_status(profile)
+        return Observation(profile=profile, status=status)
+
+    async def evaluate(self, observation: Observation) -> List[Recommendation]:
+        greens = tuple(observation.status.data.get("green_phases") or ())
+        if greens == self._expected:
+            return []
+        return [
+            Recommendation(
+                intent="operator_verify_intersection",
+                reason=(
+                    f"green phases {list(greens)} != expected "
+                    f"{list(self._expected)}"
+                ),
+                payload={
+                    "actual_greens": list(greens),
+                    "expected_greens": list(self._expected),
+                    "phase_map": observation.status.data.get("phase_map", {}),
+                },
+                profile_id=observation.profile.profile_id,
+                policy_id=self.policy_id,
+                confidence=0.8,
+            )
+        ]

--- a/src/its/profile.py
+++ b/src/its/profile.py
@@ -1,0 +1,106 @@
+"""
+Device profile model -- sanitized packs that replicate field reality.
+
+Profiles are data, not code. Store YAML/JSON under ``profiles/`` with no
+secrets (no communities, passwords, badge data, or prod API keys).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    """Sanitized description of a field (or lab) device / site asset."""
+
+    profile_id: str
+    domain: str
+    display_name: str
+    protocol: str
+    endpoint: str
+    identity: str = ""
+    capabilities: tuple = ()
+    mib_or_api_revision: str = ""
+    notes: str = ""
+    quirks: tuple = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def supports(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+
+def device_profile_from_dict(data: Mapping[str, Any]) -> DeviceProfile:
+    """Build a :class:`DeviceProfile` from a mapping (YAML/JSON object)."""
+    required = ("profile_id", "domain", "display_name", "protocol", "endpoint")
+    missing = [key for key in required if key not in data]
+    if missing:
+        raise ValueError(f"profile missing required fields: {missing}")
+
+    capabilities = tuple(data.get("capabilities") or ())
+    quirks = tuple(data.get("quirks") or ())
+    metadata = dict(data.get("metadata") or {})
+    return DeviceProfile(
+        profile_id=str(data["profile_id"]),
+        domain=str(data["domain"]).lower(),
+        display_name=str(data["display_name"]),
+        protocol=str(data["protocol"]).lower(),
+        endpoint=str(data["endpoint"]),
+        identity=str(data.get("identity") or ""),
+        capabilities=capabilities,
+        mib_or_api_revision=str(data.get("mib_or_api_revision") or ""),
+        notes=str(data.get("notes") or ""),
+        quirks=quirks,
+        metadata=metadata,
+    )
+
+
+def load_device_profile(path: Path) -> DeviceProfile:
+    """
+    Load a profile from JSON or YAML.
+
+    YAML requires PyYAML; JSON always works with the stdlib.
+    """
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        data = json.loads(text)
+    elif suffix in (".yaml", ".yml"):
+        data = _load_yaml(text, path)
+    else:
+        # Prefer JSON; attempt YAML as fallback for extensionless files.
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            data = _load_yaml(text, path)
+    if not isinstance(data, dict):
+        raise ValueError(f"profile root must be a mapping: {path}")
+    return device_profile_from_dict(data)
+
+
+def _load_yaml(text: str, path: Path) -> Dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            f"PyYAML is required to load {path}. Use .json or pip install pyyaml."
+        ) from exc
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML profile root must be a mapping: {path}")
+    return data
+
+
+def list_profile_paths(root: Path) -> List[Path]:
+    """Return profile file paths under ``root`` (json/yaml)."""
+    root = Path(root)
+    if not root.exists():
+        return []
+    paths: List[Path] = []
+    for pattern in ("*.json", "*.yaml", "*.yml"):
+        paths.extend(sorted(root.rglob(pattern)))
+    return paths

--- a/src/its/registry.py
+++ b/src/its/registry.py
@@ -1,0 +1,34 @@
+"""In-process registry of domain adapters keyed by domain name."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from its.adapters import DomainAdapter
+
+
+class AdapterRegistry:
+    """Simple composition helper for playbooks and demos."""
+
+    def __init__(self) -> None:
+        self._adapters: Dict[str, DomainAdapter] = {}
+
+    def register(self, adapter: DomainAdapter) -> None:
+        domain = adapter.domain.lower()
+        self._adapters[domain] = adapter
+
+    def get(self, domain: str) -> DomainAdapter:
+        key = domain.lower()
+        try:
+            return self._adapters[key]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._adapters)) or "(none)"
+            raise KeyError(
+                f"no adapter registered for domain={domain!r}; known={known}"
+            ) from exc
+
+    def get_optional(self, domain: str) -> Optional[DomainAdapter]:
+        return self._adapters.get(domain.lower())
+
+    def domains(self) -> tuple:
+        return tuple(sorted(self._adapters))

--- a/src/its/shadow.py
+++ b/src/its/shadow.py
@@ -1,0 +1,55 @@
+"""
+Shadow bus -- append-only log of would-be actions.
+
+Use this before granting any policy permission to call apply(dry_run=False).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from its.events import Recommendation
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ShadowBus:
+    """In-memory (optionally file-backed) recommendation log."""
+
+    records: List[Recommendation] = field(default_factory=list)
+    persist_path: Optional[Path] = None
+
+    def record(self, recommendation: Recommendation) -> Recommendation:
+        self.records.append(recommendation)
+        logger.info(
+            "SHADOW intent=%s profile=%s policy=%s reason=%s",
+            recommendation.intent,
+            recommendation.profile_id,
+            recommendation.policy_id,
+            recommendation.reason,
+        )
+        if self.persist_path is not None:
+            self._append_file(recommendation)
+        return recommendation
+
+    def record_many(
+        self, recommendations: List[Recommendation]
+    ) -> List[Recommendation]:
+        return [self.record(item) for item in recommendations]
+
+    def clear(self) -> None:
+        self.records.clear()
+
+    def to_dicts(self) -> List[dict]:
+        return [item.to_dict() for item in self.records]
+
+    def _append_file(self, recommendation: Recommendation) -> None:
+        assert self.persist_path is not None
+        self.persist_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.persist_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(recommendation.to_dict()) + "\n")

--- a/src/ntcip/__init__.py
+++ b/src/ntcip/__init__.py
@@ -1,0 +1,29 @@
+"""
+NTCIP-compliant Intelligent Transportation Systems stack.
+
+Layered architecture (bottom-up):
+
+1. ``ntcip.protocol``  - SNMPv1/v2c/v3 engine abstraction (async UDP)
+2. ``ntcip.mib``       - OID registry, ASN.1 BER types, domain objects
+3. ``ntcip.business``  - Manager/Agent facade and business intents
+
+References:
+    - NTCIP 1103: Transportation Management Protocols
+    - NTCIP 1201: Global Object Definitions
+    - NTCIP 1202: Object Definitions for ASC
+    - NTCIP 8004: Structure and Identification of Management Information
+"""
+
+from ntcip.business.manager import NtcipManager
+from ntcip.mib.date_and_time import NtcipDateAndTime
+from ntcip.mib.registry import MibRegistry
+from ntcip.protocol.async_engine import AsyncSnmpEngine
+
+__all__ = [
+    "AsyncSnmpEngine",
+    "MibRegistry",
+    "NtcipDateAndTime",
+    "NtcipManager",
+]
+
+__version__ = "0.1.0"

--- a/src/ntcip/__main__.py
+++ b/src/ntcip/__main__.py
@@ -1,0 +1,89 @@
+"""
+Usage example: NTCIP Manager asynchronously GETs ASC phase status.
+
+Run::
+
+    python -m ntcip
+    # or
+    python src/ntcip/__main__.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Allow `python src/ntcip/__main__.py` without installing the package.
+_SRC = Path(__file__).resolve().parents[1]
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from ntcip.exceptions import (  # noqa: E402
+    NtcipError,
+    OidMismatchError,
+    SnmpAuthenticationError,
+    SnmpTimeoutError,
+)
+from ntcip.factory import create_ntcip_manager  # noqa: E402
+from ntcip.protocol.models import SnmpCredentials  # noqa: E402
+
+
+async def run_phase_status_demo(host: str = "192.0.2.10") -> int:
+    """
+    Business-layer demo: async GET of phase status from a field controller.
+
+    Uses the stub SNMP backend with seeded NTCIP 1202 values so the example
+    runs offline. Swap ``use_pysnmp=True`` (and implement the backend) to
+    talk to a real cabinet.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+    log = logging.getLogger("ntcip.demo")
+
+    credentials = SnmpCredentials(community="public")
+    manager = create_ntcip_manager(credentials=credentials, demo_data=True)
+
+    try:
+        log.info("Requesting phase status from controller %s ...", host)
+        snapshot = await manager.get_phase_status(
+            host,
+            timeout_seconds=2.0,
+        )
+        summary = snapshot.summary()
+        log.info("Typed response received from %s", snapshot.host)
+        log.info("Green phases : %s", snapshot.green_phases())
+        log.info("Phase map    : %s", summary)
+
+        identity = await manager.get_unit_identity(host)
+        log.info(
+            "Unit identity : id=%s location=%s",
+            identity.unit_id,
+            identity.unit_location,
+        )
+        return 0
+    except SnmpTimeoutError as exc:
+        log.error("Network timeout: %s", exc)
+        return 2
+    except SnmpAuthenticationError as exc:
+        log.error("SNMP authentication failure: %s", exc)
+        return 3
+    except OidMismatchError as exc:
+        log.error("OID / ASN.1 mismatch: %s", exc)
+        return 4
+    except NtcipError as exc:
+        log.error("NTCIP error: %s", exc)
+        return 1
+    finally:
+        await manager.close()
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(run_phase_status_demo()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ntcip/business/__init__.py
+++ b/src/ntcip/business/__init__.py
@@ -1,0 +1,15 @@
+"""
+Layer 3: Business Logic Adapter.
+
+Translates high-level ITS intents (e.g. read phase status, set timing plan)
+into NTCIP GET/SET operations via the Manager facade.
+"""
+
+from ntcip.business.intents import PhaseStatusSnapshot, SetSignalTimingPlan
+from ntcip.business.manager import NtcipManager
+
+__all__ = [
+    "NtcipManager",
+    "PhaseStatusSnapshot",
+    "SetSignalTimingPlan",
+]

--- a/src/ntcip/business/adapters/__init__.py
+++ b/src/ntcip/business/adapters/__init__.py
@@ -1,0 +1,9 @@
+"""Adapters that expand business intents into SNMP operations."""
+
+from ntcip.business.adapters.phase_adapter import PhaseStatusAdapter
+from ntcip.business.adapters.timing_adapter import SignalTimingPlanAdapter
+
+__all__ = [
+    "PhaseStatusAdapter",
+    "SignalTimingPlanAdapter",
+]

--- a/src/ntcip/business/adapters/phase_adapter.py
+++ b/src/ntcip/business/adapters/phase_adapter.py
@@ -1,0 +1,75 @@
+"""Adapter: ASC phase status GET -> :class:`PhaseStatusSnapshot`."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ntcip.business.intents import PhaseStatusSnapshot
+from ntcip.exceptions import BusinessLogicError, NtcipError
+from ntcip.mib.interfaces import MibObjectMapper
+from ntcip.mib.objects.asc_1202 import (
+    PHASE_STATUS_GROUP_GREENS_OID,
+    PHASE_STATUS_GROUP_REDS_OID,
+    PHASE_STATUS_GROUP_YELLOWS_OID,
+    PhaseStatusGroup,
+)
+from ntcip.protocol.interfaces import SnmpEngine
+from ntcip.protocol.models import SnmpCredentials
+
+logger = logging.getLogger(__name__)
+
+
+class PhaseStatusAdapter:
+    """
+    Translates "get current phase status" into three NTCIP GETs
+    (reds/yellows/greens status groups) and a typed snapshot.
+    """
+
+    def __init__(self, engine: SnmpEngine, mapper: MibObjectMapper) -> None:
+        self._engine = engine
+        self._mapper = mapper
+
+    async def get_phase_status(
+        self,
+        host: str,
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> PhaseStatusSnapshot:
+        oids = (
+            PHASE_STATUS_GROUP_REDS_OID,
+            PHASE_STATUS_GROUP_YELLOWS_OID,
+            PHASE_STATUS_GROUP_GREENS_OID,
+        )
+        try:
+            response = await self._engine.get_async(
+                host,
+                oids,
+                credentials=credentials,
+                timeout_seconds=timeout_seconds,
+            )
+        except NtcipError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise BusinessLogicError(f"phase status GET failed: {exc}") from exc
+
+        if len(response.varbinds) != 3:
+            raise BusinessLogicError(
+                f"expected 3 varbinds for phase status, got {len(response.varbinds)}"
+            )
+
+        reds = self._mapper.to_domain_as(response.varbinds[0], PhaseStatusGroup)
+        yellows = self._mapper.to_domain_as(response.varbinds[1], PhaseStatusGroup)
+        greens = self._mapper.to_domain_as(response.varbinds[2], PhaseStatusGroup)
+
+        snapshot = PhaseStatusSnapshot(
+            host=host, greens=greens, yellows=yellows, reds=reds
+        )
+        logger.info(
+            "Phase status from %s: greens=%s summary=%s",
+            host,
+            greens.active_phases(),
+            snapshot.summary(),
+        )
+        return snapshot

--- a/src/ntcip/business/adapters/timing_adapter.py
+++ b/src/ntcip/business/adapters/timing_adapter.py
@@ -1,0 +1,71 @@
+"""Adapter: SetSignalTimingPlan intent -> NTCIP SET operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ntcip.business.intents import SetSignalTimingPlan
+from ntcip.exceptions import BusinessLogicError, NtcipError
+from ntcip.mib.interfaces import MibObjectMapper
+from ntcip.protocol.interfaces import SnmpEngine
+from ntcip.protocol.models import SnmpCredentials, SnmpVarBind, SnmpVersion
+
+logger = logging.getLogger(__name__)
+
+# Scaffold OID: ASC pattern / timing plan selection leaf.
+# Align with your compiled NTCIP 1202 pattern table before production use.
+PATTERN_CONTROL_OID = "1.3.6.1.4.1.1206.4.2.1.5.1.0"
+
+
+class SignalTimingPlanAdapter:
+    """
+    Expands :class:`SetSignalTimingPlan` into an SNMP SET.
+
+    Production adapters typically write pattern, split, and coordination
+    tables transactionally using NTCIP 1201 database transaction objects.
+    """
+
+    def __init__(self, engine: SnmpEngine, mapper: MibObjectMapper) -> None:
+        self._engine = engine
+        self._mapper = mapper
+
+    async def apply(
+        self,
+        intent: SetSignalTimingPlan,
+        *,
+        timeout_seconds: float = 2.0,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> None:
+        try:
+            intent.validate()
+        except ValueError as exc:
+            raise BusinessLogicError(str(exc)) from exc
+
+        creds = credentials or SnmpCredentials(
+            community=intent.community,
+            version=SnmpVersion.V2C,
+        )
+        # Pattern control is not in the default registry scaffold; send raw.
+        varbind = SnmpVarBind(
+            oid=PATTERN_CONTROL_OID,
+            value=intent.plan_number,
+            asn1_type="INTEGER",
+        )
+        try:
+            await self._engine.set_async(
+                intent.host,
+                [varbind],
+                credentials=creds,
+                timeout_seconds=timeout_seconds,
+            )
+        except NtcipError:
+            raise
+        except Exception as exc:  # pragma: no cover
+            raise BusinessLogicError(f"timing plan SET failed: {exc}") from exc
+
+        logger.info(
+            "Applied timing plan %s to %s", intent.plan_number, intent.host
+        )
+        # mapper retained for future transactional / typed SETs
+        _ = self._mapper

--- a/src/ntcip/business/intents.py
+++ b/src/ntcip/business/intents.py
@@ -1,0 +1,63 @@
+"""Business-level intent and result types (Layer 3)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ntcip.mib.objects.asc_1202 import PhaseStatusGroup
+
+
+@dataclass(frozen=True)
+class PhaseStatusSnapshot:
+    """Typed view of ASC phase color status for one controller."""
+
+    host: str
+    greens: PhaseStatusGroup
+    yellows: PhaseStatusGroup
+    reds: PhaseStatusGroup
+
+    def green_phases(self) -> List[int]:
+        return self.greens.active_phases()
+
+    def summary(self) -> Dict[int, str]:
+        """Map phase number -> R/Y/G (G wins if multiple bits are set)."""
+        result: Dict[int, str] = {}
+        for phase in range(1, 9):
+            if self.greens.is_active(phase):
+                result[phase] = "G"
+            elif self.yellows.is_active(phase):
+                result[phase] = "Y"
+            elif self.reds.is_active(phase):
+                result[phase] = "R"
+            else:
+                result[phase] = "-"
+        return result
+
+
+@dataclass(frozen=True)
+class SetSignalTimingPlan:
+    """
+    Example business intent: apply a named timing plan to a controller.
+
+    The adapter expands this into one or more NTCIP SET operations against
+    ASC pattern / split tables (scaffold: plan identifier only).
+    """
+
+    host: str
+    plan_number: int
+    community: str = "private"
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.plan_number < 1 or self.plan_number > 255:
+            raise ValueError("plan_number must be in 1..255")
+
+
+@dataclass(frozen=True)
+class UnitIdentity:
+    """NTCIP 1201 unit identification snapshot."""
+
+    host: str
+    unit_id: str
+    unit_location: Optional[str] = None

--- a/src/ntcip/business/manager.py
+++ b/src/ntcip/business/manager.py
@@ -1,0 +1,158 @@
+"""
+NTCIP Manager facade (Central System role).
+
+The same abstraction can later host an Agent (field device) implementation
+by swapping the facade; Layer 1/2 remain shared.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+from ntcip.business.adapters.phase_adapter import PhaseStatusAdapter
+from ntcip.business.adapters.timing_adapter import SignalTimingPlanAdapter
+from ntcip.business.intents import (
+    PhaseStatusSnapshot,
+    SetSignalTimingPlan,
+    UnitIdentity,
+)
+from ntcip.exceptions import BusinessLogicError, NtcipError
+from ntcip.mib.interfaces import MibObjectMapper
+from ntcip.mib.objects.global_1201 import UNIT_ID_OID, UNIT_LOCATION_OID
+from ntcip.protocol.interfaces import SnmpEngine
+from ntcip.protocol.models import SnmpCredentials, SnmpResponse
+
+logger = logging.getLogger(__name__)
+
+
+class NtcipManager:
+    """
+    Central-system entry point for NTCIP operations.
+
+    Business callers depend on this facade (Interface Segregation) rather
+    than on SNMP or MIB internals.
+    """
+
+    def __init__(
+        self,
+        engine: SnmpEngine,
+        mapper: MibObjectMapper,
+        *,
+        default_credentials: Optional[SnmpCredentials] = None,
+    ) -> None:
+        self._engine = engine
+        self._mapper = mapper
+        self._default_credentials = default_credentials or SnmpCredentials()
+        self._phase_adapter = PhaseStatusAdapter(engine, mapper)
+        self._timing_adapter = SignalTimingPlanAdapter(engine, mapper)
+
+    # -- low-level typed access ------------------------------------------------
+
+    async def get_object(
+        self,
+        host: str,
+        oid: str,
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> object:
+        """GET a single OID and decode it to a domain value."""
+        response = await self._engine.get_async(
+            host,
+            [oid],
+            credentials=credentials or self._default_credentials,
+            timeout_seconds=timeout_seconds,
+        )
+        if not response.varbinds:
+            raise BusinessLogicError(f"empty GET response for {oid} from {host}")
+        return self._mapper.to_domain(response.varbinds[0])
+
+    async def set_object(
+        self,
+        host: str,
+        oid: str,
+        value: object,
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> SnmpResponse:
+        """SET a single OID from a domain value (encoded via the mapper)."""
+        varbind = self._mapper.to_varbind(oid, value)
+        return await self._engine.set_async(
+            host,
+            [varbind],
+            credentials=credentials or self._default_credentials,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def get_objects(
+        self,
+        host: str,
+        oids: Sequence[str],
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> list:
+        """GET multiple OIDs; return a list of decoded domain values."""
+        response = await self._engine.get_async(
+            host,
+            oids,
+            credentials=credentials or self._default_credentials,
+            timeout_seconds=timeout_seconds,
+        )
+        return [self._mapper.to_domain(vb) for vb in response.varbinds]
+
+    # -- business intents ------------------------------------------------------
+
+    async def get_phase_status(
+        self,
+        host: str,
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> PhaseStatusSnapshot:
+        """
+        Asynchronously read ASC phase status (NTCIP 1202) from a controller.
+
+        This is the primary Manager-side GET example for the scaffold.
+        """
+        return await self._phase_adapter.get_phase_status(
+            host,
+            credentials=credentials or self._default_credentials,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def set_signal_timing_plan(
+        self,
+        intent: SetSignalTimingPlan,
+        *,
+        timeout_seconds: float = 2.0,
+    ) -> None:
+        """Apply a timing-plan business intent via NTCIP SET."""
+        await self._timing_adapter.apply(intent, timeout_seconds=timeout_seconds)
+
+    async def get_unit_identity(
+        self,
+        host: str,
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        timeout_seconds: float = 2.0,
+    ) -> UnitIdentity:
+        """Read NTCIP 1201 unitID / unitLocation."""
+        try:
+            values = await self.get_objects(
+                host,
+                [UNIT_ID_OID, UNIT_LOCATION_OID],
+                credentials=credentials,
+                timeout_seconds=timeout_seconds,
+            )
+        except NtcipError:
+            raise
+        unit_id = str(values[0]) if values[0] is not None else ""
+        location = str(values[1]) if values[1] is not None else None
+        return UnitIdentity(host=host, unit_id=unit_id, unit_location=location)
+
+    async def close(self) -> None:
+        """Release protocol resources."""
+        await self._engine.close()

--- a/src/ntcip/exceptions.py
+++ b/src/ntcip/exceptions.py
@@ -1,0 +1,84 @@
+"""
+Shared exception hierarchy for the NTCIP stack.
+
+All layers raise subclasses of :class:`NtcipError` so callers can catch
+transport, authentication, and object-mapping failures uniformly.
+"""
+
+from __future__ import annotations
+
+
+class NtcipError(Exception):
+    """Base exception for all NTCIP stack failures."""
+
+
+class SnmpError(NtcipError):
+    """Layer 1: SNMP protocol / transport failure."""
+
+
+class SnmpTimeoutError(SnmpError):
+    """No response received before the configured timeout expired."""
+
+    def __init__(self, host: str, oid: str, timeout_seconds: float) -> None:
+        self.host = host
+        self.oid = oid
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"SNMP timeout after {timeout_seconds:.2f}s talking to {host} "
+            f"for OID {oid}"
+        )
+
+
+class SnmpAuthenticationError(SnmpError):
+    """SNMPv1/v2c community or SNMPv3 USM credentials were rejected."""
+
+    def __init__(self, host: str, detail: str = "authentication failure") -> None:
+        self.host = host
+        self.detail = detail
+        super().__init__(f"SNMP authentication failed for {host}: {detail}")
+
+
+class SnmpTransportError(SnmpError):
+    """UDP send/receive or socket-level failure."""
+
+    def __init__(self, host: str, detail: str) -> None:
+        self.host = host
+        self.detail = detail
+        super().__init__(f"SNMP transport error for {host}: {detail}")
+
+
+class MibError(NtcipError):
+    """Layer 2: MIB registry / OID mapping failure."""
+
+
+class OidNotFoundError(MibError):
+    """Requested OID is not registered in the MIB tree."""
+
+    def __init__(self, oid: str) -> None:
+        self.oid = oid
+        super().__init__(f"OID not found in MIB registry: {oid}")
+
+
+class OidMismatchError(MibError):
+    """
+    Runtime value type does not match the ASN.1 type declared for the OID.
+
+    Per NTCIP practice, Managers must validate returned SYNTAX against the
+    MIB definition before promoting a value into a domain object.
+    """
+
+    def __init__(self, oid: str, expected: str, actual: str) -> None:
+        self.oid = oid
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"OID type mismatch for {oid}: expected {expected}, got {actual}"
+        )
+
+
+class Asn1CodecError(MibError):
+    """ASN.1 BER encode/decode failure for an NTCIP data type."""
+
+
+class BusinessLogicError(NtcipError):
+    """Layer 3: invalid business intent or adapter failure."""

--- a/src/ntcip/factory.py
+++ b/src/ntcip/factory.py
@@ -1,0 +1,77 @@
+"""
+Composition root for the NTCIP stack.
+
+Wires Layer 1 (engine) + Layer 2 (registry/mapper) + Layer 3 (manager)
+without leaking concrete dependencies into business callers.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ntcip.business.manager import NtcipManager
+from ntcip.mib.mapper import DefaultMibObjectMapper
+from ntcip.mib.registry import MibRegistry, build_default_ntcip_registry
+from ntcip.protocol.async_engine import AsyncSnmpEngine
+from ntcip.protocol.backends import PysnmpBackend, StubSnmpBackend
+from ntcip.protocol.interfaces import SnmpBackend
+from ntcip.mib.date_and_time import NtcipDateAndTime
+from ntcip.mib.objects.asc_1202 import (
+    PHASE_STATUS_GROUP_GREENS_OID,
+    PHASE_STATUS_GROUP_REDS_OID,
+    PHASE_STATUS_GROUP_YELLOWS_OID,
+)
+from ntcip.mib.objects.global_1201 import UNIT_ID_OID, UNIT_LOCATION_OID
+from ntcip.protocol.models import SnmpCredentials
+
+
+def create_stub_backend_with_demo_data() -> StubSnmpBackend:
+    """Backend pre-seeded with realistic ASC / global demo values."""
+    backend = StubSnmpBackend(latency_seconds=0.01)
+    # Phases 2 and 5 green (bit 1 and bit 4) -- typical SB left + SB thru.
+    green_bits = bytes([0b00010010])  # phases 2 and 5
+    red_bits = bytes([0b11101101])  # everyone else red
+    yellow_bits = bytes([0b00000000])
+    backend.seed(PHASE_STATUS_GROUP_GREENS_OID, green_bits, "OCTET STRING")
+    backend.seed(PHASE_STATUS_GROUP_YELLOWS_OID, yellow_bits, "OCTET STRING")
+    backend.seed(PHASE_STATUS_GROUP_REDS_OID, red_bits, "OCTET STRING")
+    backend.seed(UNIT_ID_OID, "ASC-DEMO-001", "DisplayString")
+    backend.seed(UNIT_LOCATION_OID, "Main St & 1st Ave", "DisplayString")
+    backend.seed(
+        "1.3.6.1.4.1.1206.4.2.6.3.2.0",
+        NtcipDateAndTime(2026, 8, 3, 12, 0, 0, 0).to_octets(),
+        "DateAndTime",
+    )
+    return backend
+
+
+def create_ntcip_manager(
+    *,
+    backend: Optional[SnmpBackend] = None,
+    registry: Optional[MibRegistry] = None,
+    credentials: Optional[SnmpCredentials] = None,
+    use_pysnmp: bool = False,
+    demo_data: bool = True,
+) -> NtcipManager:
+    """
+    Build a fully wired :class:`NtcipManager`.
+
+    Args:
+        backend: Optional custom SNMP backend.
+        registry: Optional MIB registry (defaults to 1201/1202 scaffold).
+        credentials: Default SNMPv2c/v3 credentials.
+        use_pysnmp: If True and no backend given, use :class:`PysnmpBackend`.
+        demo_data: Seed the stub backend with demo OID values.
+    """
+    if backend is None:
+        if use_pysnmp:
+            backend = PysnmpBackend()
+        elif demo_data:
+            backend = create_stub_backend_with_demo_data()
+        else:
+            backend = StubSnmpBackend()
+
+    engine = AsyncSnmpEngine(backend, default_credentials=credentials)
+    reg = registry or build_default_ntcip_registry()
+    mapper = DefaultMibObjectMapper(reg)
+    return NtcipManager(engine, mapper, default_credentials=credentials)

--- a/src/ntcip/mib/__init__.py
+++ b/src/ntcip/mib/__init__.py
@@ -1,0 +1,22 @@
+"""
+Layer 2: NTCIP Object & MIB Layer.
+
+Maps standard SNMP OIDs to strongly typed domain objects, validates ASN.1
+SYNTAX, and provides NTCIP-specific codecs (e.g. DateAndTime).
+"""
+
+from ntcip.mib.date_and_time import NtcipDateAndTime
+from ntcip.mib.interfaces import MibObjectMapper
+from ntcip.mib.mapper import DefaultMibObjectMapper
+from ntcip.mib.registry import MibRegistry, MibRegistryBuilder
+from ntcip.mib.types import Asn1Type, MibObjectDefinition
+
+__all__ = [
+    "Asn1Type",
+    "DefaultMibObjectMapper",
+    "MibObjectDefinition",
+    "MibObjectMapper",
+    "MibRegistry",
+    "MibRegistryBuilder",
+    "NtcipDateAndTime",
+]

--- a/src/ntcip/mib/date_and_time.py
+++ b/src/ntcip/mib/date_and_time.py
@@ -1,0 +1,191 @@
+"""
+NTCIP DateAndTime codec (8-octet OCTET STRING).
+
+Per NTCIP 1201 Global Object Definitions, DateAndTime is encoded as:
+
+=======  ======  ==================  =========
+Field    Octets  Contents            Range
+=======  ======  ==================  =========
+1        1-2     year (big-endian)   0..65535
+2        3       month               1..12
+3        4       day                 1..31
+4        5       hour                0..23
+5        6       minutes             0..59
+6        7       seconds             0..60
+7        8       deci-seconds        0..9
+=======  ======  ==================  =========
+
+The textual form used in documentation is ``YYYY-MM-DD-HH-MM-SS-hh``
+where ``hh`` is the deci-second digit (0-9).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Union
+
+from ntcip.exceptions import Asn1CodecError
+
+_DateSource = Union[datetime, "NtcipDateAndTime", bytes, bytearray, str]
+
+
+@dataclass(frozen=True)
+class NtcipDateAndTime:
+    """Strongly typed NTCIP DateAndTime value."""
+
+    year: int
+    month: int
+    day: int
+    hour: int
+    minute: int
+    second: int
+    deci_second: int = 0
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    def _validate(self) -> None:
+        if not 0 <= self.year <= 65535:
+            raise Asn1CodecError(f"year out of range: {self.year}")
+        if not 1 <= self.month <= 12:
+            raise Asn1CodecError(f"month out of range: {self.month}")
+        if not 1 <= self.day <= 31:
+            raise Asn1CodecError(f"day out of range: {self.day}")
+        if not 0 <= self.hour <= 23:
+            raise Asn1CodecError(f"hour out of range: {self.hour}")
+        if not 0 <= self.minute <= 59:
+            raise Asn1CodecError(f"minute out of range: {self.minute}")
+        if not 0 <= self.second <= 60:
+            raise Asn1CodecError(f"second out of range: {self.second}")
+        if not 0 <= self.deci_second <= 9:
+            raise Asn1CodecError(f"deci-second out of range: {self.deci_second}")
+
+    # ------------------------------------------------------------------
+    # Parsers / serializers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_octets(cls, data: Union[bytes, bytearray]) -> "NtcipDateAndTime":
+        """Decode an 8-octet NTCIP DateAndTime BER payload (value octets)."""
+        if len(data) != 8:
+            raise Asn1CodecError(
+                f"DateAndTime requires 8 octets, got {len(data)}"
+            )
+        year = (data[0] << 8) | data[1]
+        return cls(
+            year=year,
+            month=data[2],
+            day=data[3],
+            hour=data[4],
+            minute=data[5],
+            second=data[6],
+            deci_second=data[7],
+        )
+
+    def to_octets(self) -> bytes:
+        """Serialize to the canonical 8-octet NTCIP encoding."""
+        self._validate()
+        return bytes(
+            [
+                (self.year >> 8) & 0xFF,
+                self.year & 0xFF,
+                self.month,
+                self.day,
+                self.hour,
+                self.minute,
+                self.second,
+                self.deci_second,
+            ]
+        )
+
+    @classmethod
+    def from_datetime(cls, dt: datetime) -> "NtcipDateAndTime":
+        """Build from a :class:`datetime` (deci-seconds from microseconds)."""
+        deci = min(9, dt.microsecond // 100_000)
+        return cls(
+            year=dt.year,
+            month=dt.month,
+            day=dt.day,
+            hour=dt.hour,
+            minute=dt.minute,
+            second=dt.second,
+            deci_second=deci,
+        )
+
+    def to_datetime(self) -> datetime:
+        """Convert to :class:`datetime` (naive, local cabinet time)."""
+        return datetime(
+            year=self.year,
+            month=self.month,
+            day=self.day,
+            hour=self.hour,
+            minute=self.minute,
+            second=min(self.second, 59),
+            microsecond=self.deci_second * 100_000,
+        )
+
+    @classmethod
+    def parse(cls, text: str) -> "NtcipDateAndTime":
+        """
+        Parse ``YYYY-MM-DD-HH-MM-SS-hh`` (hyphen-separated, 7 fields).
+
+        Also accepts ISO-8601 ``YYYY-MM-DDTHH:MM:SS`` (deci-second = 0).
+        """
+        text = text.strip()
+        if "T" in text:
+            dt = datetime.fromisoformat(text)
+            return cls.from_datetime(dt)
+        parts = text.split("-")
+        if len(parts) != 7:
+            raise Asn1CodecError(
+                "DateAndTime text must be YYYY-MM-DD-HH-MM-SS-hh "
+                f"(got {len(parts)} fields)"
+            )
+        try:
+            nums = [int(p) for p in parts]
+        except ValueError as exc:
+            raise Asn1CodecError(f"invalid DateAndTime text: {text}") from exc
+        return cls(
+            year=nums[0],
+            month=nums[1],
+            day=nums[2],
+            hour=nums[3],
+            minute=nums[4],
+            second=nums[5],
+            deci_second=nums[6],
+        )
+
+    def format(self) -> str:
+        """Format as ``YYYY-MM-DD-HH-MM-SS-hh``."""
+        return (
+            f"{self.year:04d}-{self.month:02d}-{self.day:02d}-"
+            f"{self.hour:02d}-{self.minute:02d}-{self.second:02d}-"
+            f"{self.deci_second:01d}"
+        )
+
+    def __str__(self) -> str:
+        return self.format()
+
+    @classmethod
+    def coerce(cls, value: _DateSource) -> "NtcipDateAndTime":
+        """Best-effort conversion from common source types."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, datetime):
+            return cls.from_datetime(value)
+        if isinstance(value, (bytes, bytearray)):
+            return cls.from_octets(value)
+        if isinstance(value, str):
+            return cls.parse(value)
+        raise Asn1CodecError(f"cannot coerce {type(value)!r} to DateAndTime")
+
+
+def decode_date_and_time(raw: object) -> NtcipDateAndTime:
+    """MIB decoder hook."""
+    return NtcipDateAndTime.coerce(raw)  # type: ignore[arg-type]
+
+
+def encode_date_and_time(value: object) -> bytes:
+    """MIB encoder hook (wire value = 8 octets)."""
+    return NtcipDateAndTime.coerce(value).to_octets()  # type: ignore[arg-type]

--- a/src/ntcip/mib/interfaces.py
+++ b/src/ntcip/mib/interfaces.py
@@ -1,0 +1,43 @@
+"""Layer 2 interfaces for OID <-> domain object translation."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, Type, TypeVar, runtime_checkable
+
+from ntcip.mib.types import MibObjectDefinition
+from ntcip.protocol.models import SnmpVarBind
+
+T = TypeVar("T")
+
+
+@runtime_checkable
+class MibObjectMapper(Protocol):
+    """
+    Translates SNMP varbinds to/from strongly typed domain values.
+
+    Implementations consult a :class:`~ntcip.mib.registry.MibRegistry` for
+    SYNTAX metadata and optional codec hooks.
+    """
+
+    def resolve(self, oid: str) -> MibObjectDefinition:
+        """Look up the MIB definition for an OID (exact or prefix)."""
+
+    def to_domain(self, varbind: SnmpVarBind) -> Any:
+        """Decode a varbind into a domain value using the registered codec."""
+
+    def to_domain_as(self, varbind: SnmpVarBind, domain_type: Type[T]) -> T:
+        """Decode and assert the result is an instance of ``domain_type``."""
+
+    def to_varbind(self, oid: str, value: Any) -> SnmpVarBind:
+        """Encode a domain value into a varbind for SNMP SET."""
+
+    def validate_type(
+        self, oid: str, reported_asn1_type: Optional[str]
+    ) -> MibObjectDefinition:
+        """
+        Ensure the reported ASN.1 type is compatible with the MIB SYNTAX.
+
+        Raises:
+            OidMismatchError: on incompatible types.
+            OidNotFoundError: if the OID is unknown.
+        """

--- a/src/ntcip/mib/mapper.py
+++ b/src/ntcip/mib/mapper.py
@@ -1,0 +1,88 @@
+"""Default :class:`MibObjectMapper` implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Type, TypeVar
+
+from ntcip.exceptions import OidMismatchError
+from ntcip.mib.registry import MibRegistry
+from ntcip.mib.types import Asn1Type, MibObjectDefinition
+from ntcip.protocol.models import SnmpVarBind
+
+T = TypeVar("T")
+
+# Types that are considered compatible for mismatch checks.
+_COMPATIBLE = {
+    Asn1Type.INTEGER: {"INTEGER", "Integer32", "INTEGER32", "int"},
+    Asn1Type.INTEGER32: {"INTEGER", "Integer32", "INTEGER32", "int"},
+    Asn1Type.UNSIGNED32: {"Unsigned32", "Gauge32", "UNSIGNED32", "int"},
+    Asn1Type.OCTET_STRING: {"OCTET STRING", "OCTETSTRING", "bytes", "str"},
+    Asn1Type.DISPLAY_STRING: {
+        "DisplayString",
+        "OCTET STRING",
+        "OCTETSTRING",
+        "str",
+    },
+    Asn1Type.DATE_AND_TIME: {
+        "DateAndTime",
+        "OCTET STRING",
+        "OCTETSTRING",
+        "bytes",
+    },
+    Asn1Type.OBJECT_IDENTIFIER: {"OBJECT IDENTIFIER", "OID"},
+    Asn1Type.COUNTER32: {"Counter32", "COUNTER32"},
+    Asn1Type.GAUGE32: {"Gauge32", "GAUGE32", "Unsigned32"},
+    Asn1Type.TIMETICKS: {"TimeTicks", "TIMETICKS"},
+}
+
+
+class DefaultMibObjectMapper:
+    """Registry-backed mapper with ASN.1 SYNTAX validation."""
+
+    def __init__(self, registry: MibRegistry) -> None:
+        self._registry = registry
+
+    @property
+    def registry(self) -> MibRegistry:
+        return self._registry
+
+    def resolve(self, oid: str) -> MibObjectDefinition:
+        return self._registry.resolve(oid)
+
+    def validate_type(
+        self, oid: str, reported_asn1_type: Optional[str]
+    ) -> MibObjectDefinition:
+        definition = self._registry.resolve(oid)
+        if reported_asn1_type is None:
+            return definition
+        expected = definition.asn1_type
+        allowed = _COMPATIBLE.get(expected, {expected.value})
+        normalized = reported_asn1_type.strip()
+        if normalized not in allowed and normalized != expected.value:
+            raise OidMismatchError(oid, expected.value, normalized)
+        return definition
+
+    def to_domain(self, varbind: SnmpVarBind) -> Any:
+        definition = self.validate_type(varbind.oid, varbind.asn1_type)
+        return definition.decode(varbind.value)
+
+    def to_domain_as(self, varbind: SnmpVarBind, domain_type: Type[T]) -> T:
+        value = self.to_domain(varbind)
+        if not isinstance(value, domain_type):
+            raise OidMismatchError(
+                varbind.oid,
+                domain_type.__name__,
+                type(value).__name__,
+            )
+        return value
+
+    def to_varbind(self, oid: str, value: Any) -> SnmpVarBind:
+        definition = self._registry.resolve(oid)
+        if definition.read_only:
+            raise OidMismatchError(oid, "writable object", "read-only object")
+        encoded = definition.encode(value)
+        return SnmpVarBind(
+            oid=oid,
+            value=encoded,
+            asn1_type=definition.asn1_type.value,
+        )

--- a/src/ntcip/mib/objects/__init__.py
+++ b/src/ntcip/mib/objects/__init__.py
@@ -1,0 +1,21 @@
+"""Example NTCIP MIB object definition modules."""
+
+from ntcip.mib.objects.asc_1202 import (
+    PHASE_STATUS_GROUP_GREENS_OID,
+    PhaseStatusGroup,
+    asc_1202_definitions,
+)
+from ntcip.mib.objects.global_1201 import (
+    UNIT_ID_OID,
+    UNIT_LOCATION_OID,
+    global_1201_definitions,
+)
+
+__all__ = [
+    "PHASE_STATUS_GROUP_GREENS_OID",
+    "PhaseStatusGroup",
+    "UNIT_ID_OID",
+    "UNIT_LOCATION_OID",
+    "asc_1202_definitions",
+    "global_1201_definitions",
+]

--- a/src/ntcip/mib/objects/asc_1202.py
+++ b/src/ntcip/mib/objects/asc_1202.py
@@ -1,0 +1,122 @@
+"""
+Example mappings from NTCIP 1202 -- Object Definitions for ASC.
+
+OID tree::
+
+    1.3.6.1.4.1.1206.4.2.1     -- asc (Actuated Signal Controller)
+      .1                       -- phase
+        .4                     -- phaseStatusGroupTable
+          .1                   -- phaseStatusGroupEntry
+            .2                 -- phaseStatusGroupReds
+            .3                 -- phaseStatusGroupYellows
+            .4                 -- phaseStatusGroupGreens
+
+Each status group is an OCTET STRING bitfield where bit N (1-based in the
+NTCIP sense: bit 0 of the first octet = phase 1) indicates that phase's
+red/yellow/green status is active.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ntcip.mib.types import Asn1Type, MibObjectDefinition
+
+_PHASE_STATUS_ENTRY = "1.3.6.1.4.1.1206.4.2.1.1.4.1"
+
+PHASE_STATUS_GROUP_REDS_OID = f"{_PHASE_STATUS_ENTRY}.2.1"
+PHASE_STATUS_GROUP_YELLOWS_OID = f"{_PHASE_STATUS_ENTRY}.3.1"
+PHASE_STATUS_GROUP_GREENS_OID = f"{_PHASE_STATUS_ENTRY}.4.1"
+"""phaseStatusGroupGreens.1 -- green bits for phases 1..8 (typical group)."""
+
+
+@dataclass(frozen=True)
+class PhaseStatusGroup:
+    """
+    Decoded phase status bitfield for one status group (usually phases 1-8).
+
+    NTCIP 1202 encodes eight phases per octet; bit ``(phase - 1)`` is set
+    when that color is active for the phase.
+    """
+
+    raw: bytes
+    group_index: int = 1
+
+    @classmethod
+    def from_octet(cls, value: object, group_index: int = 1) -> "PhaseStatusGroup":
+        if isinstance(value, int):
+            raw = bytes([value & 0xFF])
+        elif isinstance(value, (bytes, bytearray)):
+            raw = bytes(value)
+        elif isinstance(value, str):
+            # Allow hex strings from stubs / logs
+            raw = bytes.fromhex(value) if all(
+                c in "0123456789abcdefABCDEF" for c in value
+            ) else value.encode("ascii")
+        else:
+            raise TypeError(f"unsupported phase status value: {type(value)!r}")
+        if not raw:
+            raw = b"\x00"
+        return cls(raw=raw, group_index=group_index)
+
+    def is_active(self, phase: int) -> bool:
+        """Return True if ``phase`` (1-based) has this color active."""
+        if phase < 1:
+            raise ValueError("phase numbers are 1-based")
+        byte_index, bit_index = divmod(phase - 1, 8)
+        if byte_index >= len(self.raw):
+            return False
+        return bool(self.raw[byte_index] & (1 << bit_index))
+
+    def active_phases(self, max_phase: int = 8) -> List[int]:
+        return [p for p in range(1, max_phase + 1) if self.is_active(p)]
+
+
+def _decode_phase_status(raw: object) -> PhaseStatusGroup:
+    return PhaseStatusGroup.from_octet(raw)
+
+
+def _encode_phase_status(value: object) -> bytes:
+    if isinstance(value, PhaseStatusGroup):
+        return value.raw
+    return PhaseStatusGroup.from_octet(value).raw
+
+
+def asc_1202_definitions() -> List[MibObjectDefinition]:
+    """Return scaffold definitions for selected NTCIP 1202 ASC objects."""
+    return [
+        MibObjectDefinition(
+            oid=PHASE_STATUS_GROUP_REDS_OID,
+            name="phaseStatusGroupReds",
+            asn1_type=Asn1Type.OCTET_STRING,
+            standard="NTCIP 1202",
+            domain_type=PhaseStatusGroup,
+            description="Bitfield of phases currently showing Red.",
+            decoder=_decode_phase_status,
+            encoder=_encode_phase_status,
+            read_only=True,
+        ),
+        MibObjectDefinition(
+            oid=PHASE_STATUS_GROUP_YELLOWS_OID,
+            name="phaseStatusGroupYellows",
+            asn1_type=Asn1Type.OCTET_STRING,
+            standard="NTCIP 1202",
+            domain_type=PhaseStatusGroup,
+            description="Bitfield of phases currently showing Yellow.",
+            decoder=_decode_phase_status,
+            encoder=_encode_phase_status,
+            read_only=True,
+        ),
+        MibObjectDefinition(
+            oid=PHASE_STATUS_GROUP_GREENS_OID,
+            name="phaseStatusGroupGreens",
+            asn1_type=Asn1Type.OCTET_STRING,
+            standard="NTCIP 1202",
+            domain_type=PhaseStatusGroup,
+            description="Bitfield of phases currently showing Green (Go).",
+            decoder=_decode_phase_status,
+            encoder=_encode_phase_status,
+            read_only=True,
+        ),
+    ]

--- a/src/ntcip/mib/objects/global_1201.py
+++ b/src/ntcip/mib/objects/global_1201.py
@@ -1,0 +1,78 @@
+"""
+Example mappings from NTCIP 1201 -- Global Object Definitions.
+
+OID tree (NTCIP 8004 / NEMA enterprise)::
+
+    1.3.6.1.4.1.1206.4.2.6   -- global (NTCIP 1201)
+      .1                     -- globalConfiguration
+      .3                     -- globalTime
+      .4                     -- unit (identification / location parameters)
+
+The ``unitID`` and ``unitLocation`` objects below follow the common NTCIP
+1201 unit-parameter layout used by ASC and DMS field devices. Exact leaf
+numbers can vary slightly by MIB revision; treat these as scaffold defaults
+and align with your vendor's compiled MIB under ``mibs/``.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from ntcip.mib.date_and_time import decode_date_and_time, encode_date_and_time
+from ntcip.mib.types import Asn1Type, MibObjectDefinition
+
+# profiles.global.unit
+_UNIT_BASE = "1.3.6.1.4.1.1206.4.2.6.4"
+
+UNIT_ID_OID = f"{_UNIT_BASE}.3.0"
+"""unitID -- unique controller identifier (DisplayString)."""
+
+UNIT_LOCATION_OID = f"{_UNIT_BASE}.7.0"
+"""unitLocation -- human-readable intersection / cabinet location."""
+
+# profiles.global.globalTime.globalLocalTimeBase (DateAndTime)
+GLOBAL_LOCAL_TIME_OID = "1.3.6.1.4.1.1206.4.2.6.3.2.0"
+"""global local time -- NTCIP DateAndTime (8 octets)."""
+
+# profiles.global.globalConfiguration.globalSetIDParameter
+GLOBAL_SET_ID_OID = "1.3.6.1.4.1.1206.4.2.6.1.1.0"
+"""Database set identifier for configuration consistency checks."""
+
+
+def global_1201_definitions() -> List[MibObjectDefinition]:
+    """Return scaffold definitions for selected NTCIP 1201 objects."""
+    return [
+        MibObjectDefinition(
+            oid=UNIT_ID_OID,
+            name="unitID",
+            asn1_type=Asn1Type.DISPLAY_STRING,
+            standard="NTCIP 1201",
+            domain_type=str,
+            description="Unique identification of the field unit / controller.",
+        ),
+        MibObjectDefinition(
+            oid=UNIT_LOCATION_OID,
+            name="unitLocation",
+            asn1_type=Asn1Type.DISPLAY_STRING,
+            standard="NTCIP 1201",
+            domain_type=str,
+            description="Physical or logical location description of the unit.",
+        ),
+        MibObjectDefinition(
+            oid=GLOBAL_LOCAL_TIME_OID,
+            name="globalLocalTime",
+            asn1_type=Asn1Type.DATE_AND_TIME,
+            standard="NTCIP 1201",
+            description="Controller local time as NTCIP DateAndTime (8 octets).",
+            decoder=decode_date_and_time,
+            encoder=encode_date_and_time,
+        ),
+        MibObjectDefinition(
+            oid=GLOBAL_SET_ID_OID,
+            name="globalSetIDParameter",
+            asn1_type=Asn1Type.INTEGER,
+            standard="NTCIP 1201",
+            domain_type=int,
+            description="Configuration set ID parameter (globalConfiguration).",
+        ),
+    ]

--- a/src/ntcip/mib/registry.py
+++ b/src/ntcip/mib/registry.py
@@ -1,0 +1,118 @@
+"""
+Generic MIB registry / OID tree for NTCIP managed objects.
+
+Stores OID -> ASN.1 type -> domain mapping metadata. Populate via
+:class:`MibRegistryBuilder` or :func:`build_default_ntcip_registry`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from ntcip.exceptions import OidNotFoundError
+from ntcip.mib.types import MibObjectDefinition
+
+
+class MibRegistry:
+    """
+    In-memory OID catalog.
+
+    Lookup strategy:
+      1. Exact OID match (preferred for instances).
+      2. Longest-prefix match against registered columnar/scalar bases.
+    """
+
+    def __init__(self, definitions: Optional[Iterable[MibObjectDefinition]] = None) -> None:
+        self._by_oid: Dict[str, MibObjectDefinition] = {}
+        self._by_name: Dict[str, MibObjectDefinition] = {}
+        if definitions:
+            for definition in definitions:
+                self.register(definition)
+
+    def register(self, definition: MibObjectDefinition) -> None:
+        """Add or replace a MIB object definition."""
+        self._by_oid[definition.oid] = definition
+        self._by_name[definition.name] = definition
+
+    def get_by_oid(self, oid: str) -> MibObjectDefinition:
+        """Exact OID lookup."""
+        try:
+            return self._by_oid[oid]
+        except KeyError as exc:
+            raise OidNotFoundError(oid) from exc
+
+    def get_by_name(self, name: str) -> MibObjectDefinition:
+        """Symbolic name lookup."""
+        try:
+            return self._by_name[name]
+        except KeyError as exc:
+            raise OidNotFoundError(name) from exc
+
+    def resolve(self, oid: str) -> MibObjectDefinition:
+        """Exact match, else longest registered prefix."""
+        if oid in self._by_oid:
+            return self._by_oid[oid]
+        best: Optional[MibObjectDefinition] = None
+        best_len = -1
+        for registered_oid, definition in self._by_oid.items():
+            if oid == registered_oid or oid.startswith(registered_oid + "."):
+                if len(registered_oid) > best_len:
+                    best = definition
+                    best_len = len(registered_oid)
+        if best is None:
+            raise OidNotFoundError(oid)
+        return best
+
+    def __contains__(self, oid: str) -> bool:
+        try:
+            self.resolve(oid)
+            return True
+        except OidNotFoundError:
+            return False
+
+    def __iter__(self) -> Iterator[MibObjectDefinition]:
+        return iter(self._by_oid.values())
+
+    def __len__(self) -> int:
+        return len(self._by_oid)
+
+    def oids(self) -> List[str]:
+        return list(self._by_oid.keys())
+
+
+class MibRegistryBuilder:
+    """Fluent builder for composing MIB modules (1201, 1202, vendor)."""
+
+    def __init__(self) -> None:
+        self._definitions: List[MibObjectDefinition] = []
+
+    def add(self, definition: MibObjectDefinition) -> "MibRegistryBuilder":
+        self._definitions.append(definition)
+        return self
+
+    def add_all(
+        self, definitions: Iterable[MibObjectDefinition]
+    ) -> "MibRegistryBuilder":
+        self._definitions.extend(definitions)
+        return self
+
+    def build(self) -> MibRegistry:
+        return MibRegistry(self._definitions)
+
+
+def build_default_ntcip_registry() -> MibRegistry:
+    """
+    Construct a registry preloaded with example NTCIP 1201 / 1202 objects.
+
+    This is a scaffold subset -- production systems load full MIB modules
+    from ``mibs/`` (SMI parsers or generated Python bindings).
+    """
+    from ntcip.mib.objects.asc_1202 import asc_1202_definitions
+    from ntcip.mib.objects.global_1201 import global_1201_definitions
+
+    return (
+        MibRegistryBuilder()
+        .add_all(global_1201_definitions())
+        .add_all(asc_1202_definitions())
+        .build()
+    )

--- a/src/ntcip/mib/types.py
+++ b/src/ntcip/mib/types.py
@@ -1,0 +1,75 @@
+"""
+ASN.1 / MIB metadata types for Layer 2.
+
+OID naming follows NTCIP 8004 (SMI) under the NEMA enterprise tree
+``1.3.6.1.4.1.1206``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Optional, Type
+
+
+class Asn1Type(str, Enum):
+    """
+    Subset of ASN.1 / SNMPv2 SYNTAX types used by NTCIP MIBs.
+
+    Values are string tags compared against backend-reported types and used
+    for mismatch detection (:class:`~ntcip.exceptions.OidMismatchError`).
+    """
+
+    INTEGER = "INTEGER"
+    INTEGER32 = "Integer32"
+    UNSIGNED32 = "Unsigned32"
+    OCTET_STRING = "OCTET STRING"
+    OBJECT_IDENTIFIER = "OBJECT IDENTIFIER"
+    COUNTER32 = "Counter32"
+    GAUGE32 = "Gauge32"
+    TIMETICKS = "TimeTicks"
+    DISPLAY_STRING = "DisplayString"
+    DATE_AND_TIME = "DateAndTime"  # NTCIP 8-octet OCTET STRING
+
+
+# Domain decode/encode hooks bound to a MIB definition.
+Decoder = Callable[[Any], Any]
+Encoder = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class MibObjectDefinition:
+    """
+    Registry entry describing one NTCIP managed object.
+
+    Attributes:
+        oid: Dotted numeric OID (instance form, typically ending in ``.0``
+            for scalars or ``.<index>`` for columnar objects).
+        name: Symbolic MIB name (e.g. ``phaseStatusGroupGreens``).
+        asn1_type: Declared SYNTAX from the MIB module.
+        standard: Source standard identifier (e.g. ``NTCIP 1202``).
+        domain_type: Optional Python type for decoded values.
+        description: Human-readable object description.
+        decoder / encoder: Optional hooks for complex SYNTAX (DateAndTime).
+        read_only: True for read-only MAX-ACCESS objects.
+    """
+
+    oid: str
+    name: str
+    asn1_type: Asn1Type
+    standard: str
+    domain_type: Optional[Type[Any]] = None
+    description: str = ""
+    decoder: Optional[Decoder] = None
+    encoder: Optional[Encoder] = None
+    read_only: bool = False
+
+    def decode(self, raw: Any) -> Any:
+        if self.decoder is not None:
+            return self.decoder(raw)
+        return raw
+
+    def encode(self, value: Any) -> Any:
+        if self.encoder is not None:
+            return self.encoder(value)
+        return value

--- a/src/ntcip/protocol/__init__.py
+++ b/src/ntcip/protocol/__init__.py
@@ -1,0 +1,30 @@
+"""
+Layer 1: Protocol Engine (SNMP Core).
+
+Handles SNMPv1/v2c/v3 packet encode/decode and async UDP transport via a
+pluggable backend (pysnmp, gosnmp bindings, Net-SNMP, etc.). Application
+code depends only on :class:`~ntcip.protocol.interfaces.SnmpEngine`.
+"""
+
+from ntcip.protocol.async_engine import AsyncSnmpEngine
+from ntcip.protocol.interfaces import SnmpBackend, SnmpEngine
+from ntcip.protocol.models import (
+    SnmpCredentials,
+    SnmpGetRequest,
+    SnmpSetRequest,
+    SnmpVarBind,
+    SnmpVersion,
+    TrapSubscription,
+)
+
+__all__ = [
+    "AsyncSnmpEngine",
+    "SnmpBackend",
+    "SnmpCredentials",
+    "SnmpEngine",
+    "SnmpGetRequest",
+    "SnmpSetRequest",
+    "SnmpVarBind",
+    "SnmpVersion",
+    "TrapSubscription",
+]

--- a/src/ntcip/protocol/async_engine.py
+++ b/src/ntcip/protocol/async_engine.py
@@ -1,0 +1,184 @@
+"""
+Concrete async :class:`SnmpEngine` with timeout and retry policy.
+
+Wraps a pluggable :class:`SnmpBackend` so the rest of the stack never talks
+to a vendor SNMP API directly (Open/Closed + Dependency Inversion).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional, Sequence
+
+from ntcip.exceptions import SnmpError, SnmpTimeoutError, SnmpTransportError
+from ntcip.protocol.backends import StubSnmpBackend
+from ntcip.protocol.interfaces import SnmpBackend
+from ntcip.protocol.models import (
+    SnmpCredentials,
+    SnmpGetRequest,
+    SnmpResponse,
+    SnmpSetRequest,
+    SnmpVarBind,
+    TrapCallback,
+    TrapSubscription,
+    as_oid_tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncSnmpEngine:
+    """
+    Non-blocking SNMP engine for NTCIP Managers.
+
+    Concurrency model: ``asyncio`` tasks / awaitables. Each GET/SET is an
+    independent coroutine; callers may gather many in parallel toward
+    different field devices.
+    """
+
+    def __init__(
+        self,
+        backend: Optional[SnmpBackend] = None,
+        *,
+        default_credentials: Optional[SnmpCredentials] = None,
+    ) -> None:
+        self._backend: SnmpBackend = backend or StubSnmpBackend()
+        self._default_credentials = default_credentials or SnmpCredentials()
+        self._subscriptions: dict[str, TrapSubscription] = {}
+
+    async def get_async(
+        self,
+        host: str,
+        oids: Sequence[str],
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        port: int = 161,
+        timeout_seconds: float = 2.0,
+        retries: int = 1,
+    ) -> SnmpResponse:
+        request = SnmpGetRequest(
+            host=host,
+            oids=as_oid_tuple(oids),
+            credentials=credentials or self._default_credentials,
+            port=port,
+            timeout_seconds=timeout_seconds,
+            retries=retries,
+        )
+        return await self._with_retries(request, self._backend.send_get)
+
+    async def set_async(
+        self,
+        host: str,
+        varbinds: Sequence[SnmpVarBind],
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        port: int = 161,
+        timeout_seconds: float = 2.0,
+        retries: int = 1,
+    ) -> SnmpResponse:
+        if not varbinds:
+            raise ValueError("At least one varbind is required for SET")
+        request = SnmpSetRequest(
+            host=host,
+            varbinds=tuple(varbinds),
+            credentials=credentials or self._default_credentials,
+            port=port,
+            timeout_seconds=timeout_seconds,
+            retries=retries,
+        )
+        return await self._with_retries(request, self._backend.send_set)
+
+    async def subscribe_to_traps(
+        self,
+        callback: TrapCallback,
+        *,
+        listen_host: str = "0.0.0.0",
+        listen_port: int = 162,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> TrapSubscription:
+        sub = await self._backend.start_trap_listener(
+            listen_host,
+            listen_port,
+            callback,
+            credentials or self._default_credentials,
+        )
+        self._subscriptions[sub.subscription_id] = sub
+        return sub
+
+    async def unsubscribe_from_traps(self, subscription: TrapSubscription) -> None:
+        await self._backend.stop_trap_listener(subscription)
+        self._subscriptions.pop(subscription.subscription_id, None)
+
+    async def close(self) -> None:
+        for sub in list(self._subscriptions.values()):
+            try:
+                await self._backend.stop_trap_listener(sub)
+            except SnmpError:
+                logger.exception("Error stopping trap subscription %s", sub)
+        self._subscriptions.clear()
+        await self._backend.close()
+
+    async def _with_retries(self, request, send_coro) -> SnmpResponse:
+        """
+        Apply timeout + retry around a backend send call.
+
+        NTCIP field networks are lossy; a single UDP retry is typical for
+        Manager GET/SET profiles (see NTCIP 1103 retransmission guidance).
+        """
+        attempts = max(0, request.retries) + 1
+        last_error: Optional[BaseException] = None
+        oid_hint = self._oid_hint(request)
+
+        for attempt in range(attempts):
+            try:
+                return await asyncio.wait_for(
+                    send_coro(request),
+                    timeout=request.timeout_seconds,
+                )
+            except asyncio.TimeoutError as exc:
+                last_error = SnmpTimeoutError(
+                    host=request.host,
+                    oid=oid_hint,
+                    timeout_seconds=request.timeout_seconds,
+                )
+                logger.warning(
+                    "SNMP timeout host=%s oid=%s attempt=%s/%s",
+                    request.host,
+                    oid_hint,
+                    attempt + 1,
+                    attempts,
+                )
+                _ = exc
+            except SnmpTimeoutError as exc:
+                last_error = exc
+                logger.warning(
+                    "SNMP backend timeout host=%s oid=%s attempt=%s/%s",
+                    request.host,
+                    oid_hint,
+                    attempt + 1,
+                    attempts,
+                )
+            except SnmpError:
+                # Auth and explicit transport errors are not retried.
+                raise
+            except OSError as exc:
+                last_error = SnmpTransportError(request.host, str(exc))
+                logger.warning(
+                    "SNMP OSError host=%s attempt=%s/%s: %s",
+                    request.host,
+                    attempt + 1,
+                    attempts,
+                    exc,
+                )
+
+        assert last_error is not None
+        raise last_error
+
+    @staticmethod
+    def _oid_hint(request) -> str:
+        if isinstance(request, SnmpGetRequest) and request.oids:
+            return request.oids[0]
+        if isinstance(request, SnmpSetRequest) and request.varbinds:
+            return request.varbinds[0].oid
+        return "?"

--- a/src/ntcip/protocol/backends.py
+++ b/src/ntcip/protocol/backends.py
@@ -1,0 +1,201 @@
+"""
+Pluggable SNMP backends.
+
+``StubSnmpBackend`` powers unit tests and the local demo without a live
+controller. ``PysnmpBackend`` is a documented integration seam for the
+preferred library (pysnmp); wire it when the dependency is available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Dict, List, Optional
+
+from ntcip.exceptions import (
+    SnmpAuthenticationError,
+    SnmpTimeoutError,
+    SnmpTransportError,
+)
+from ntcip.protocol.models import (
+    SnmpCredentials,
+    SnmpGetRequest,
+    SnmpResponse,
+    SnmpSetRequest,
+    SnmpVarBind,
+    SnmpVersion,
+    TrapCallback,
+    TrapSubscription,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StubSnmpBackend:
+    """
+    In-memory SNMP backend for tests and offline demos.
+
+    Simulates latency, timeouts, and auth failures so Layer 2/3 can be
+    exercised without a cabinet or SNMP library.
+    """
+
+    def __init__(
+        self,
+        *,
+        values: Optional[Dict[str, SnmpVarBind]] = None,
+        latency_seconds: float = 0.01,
+        force_timeout: bool = False,
+        reject_community: Optional[str] = None,
+    ) -> None:
+        self._values: Dict[str, SnmpVarBind] = dict(values or {})
+        self._latency_seconds = latency_seconds
+        self._force_timeout = force_timeout
+        self._reject_community = reject_community
+        self._trap_subs: Dict[str, TrapSubscription] = {}
+        self._closed = False
+
+    def seed(self, oid: str, value: object, asn1_type: str = "OCTET STRING") -> None:
+        """Install or overwrite a simulated OID value."""
+        self._values[oid] = SnmpVarBind(oid=oid, value=value, asn1_type=asn1_type)
+
+    async def send_get(self, request: SnmpGetRequest) -> SnmpResponse:
+        self._ensure_open()
+        await self._simulate_network(request.host, request.oids[0], request)
+        self._check_auth(request.host, request.credentials)
+        varbinds: List[SnmpVarBind] = []
+        for oid in request.oids:
+            if oid not in self._values:
+                varbinds.append(SnmpVarBind(oid=oid, value=None, asn1_type="NULL"))
+            else:
+                varbinds.append(self._values[oid])
+        return SnmpResponse(host=request.host, varbinds=tuple(varbinds))
+
+    async def send_set(self, request: SnmpSetRequest) -> SnmpResponse:
+        self._ensure_open()
+        first_oid = request.varbinds[0].oid if request.varbinds else ""
+        await self._simulate_network(request.host, first_oid, request)
+        self._check_auth(request.host, request.credentials)
+        echoed: List[SnmpVarBind] = []
+        for vb in request.varbinds:
+            stored = SnmpVarBind(
+                oid=vb.oid, value=vb.value, asn1_type=vb.asn1_type or "OCTET STRING"
+            )
+            self._values[vb.oid] = stored
+            echoed.append(stored)
+        return SnmpResponse(host=request.host, varbinds=tuple(echoed))
+
+    async def start_trap_listener(
+        self,
+        listen_host: str,
+        listen_port: int,
+        callback: TrapCallback,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> TrapSubscription:
+        self._ensure_open()
+        sub = TrapSubscription(
+            listen_host=listen_host,
+            listen_port=listen_port,
+            subscription_id=str(uuid.uuid4()),
+        )
+        self._trap_subs[sub.subscription_id] = sub
+        logger.debug("Stub trap listener started: %s", sub.subscription_id)
+        # callback retained for future emit_trap helpers; mark used
+        _ = callback
+        _ = credentials
+        return sub
+
+    async def stop_trap_listener(self, subscription: TrapSubscription) -> None:
+        self._trap_subs.pop(subscription.subscription_id, None)
+
+    async def close(self) -> None:
+        self._trap_subs.clear()
+        self._closed = True
+
+    async def _simulate_network(
+        self,
+        host: str,
+        oid: str,
+        request: object,
+    ) -> None:
+        timeout = getattr(request, "timeout_seconds", 2.0)
+        if self._force_timeout:
+            await asyncio.sleep(0)
+            raise SnmpTimeoutError(host=host, oid=oid, timeout_seconds=timeout)
+        await asyncio.sleep(self._latency_seconds)
+
+    def _check_auth(self, host: str, credentials: SnmpCredentials) -> None:
+        if (
+            self._reject_community is not None
+            and credentials.version in (SnmpVersion.V1, SnmpVersion.V2C)
+            and credentials.community == self._reject_community
+        ):
+            raise SnmpAuthenticationError(host, "invalid community string")
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise SnmpTransportError("localhost", "backend is closed")
+
+
+class PysnmpBackend:
+    """
+    Integration seam for `pysnmp` (preferred SNMP library for this stack).
+
+    This scaffold does not vendor a full pysnmp implementation. When you add
+    ``pysnmp`` to the environment, replace the ``NotImplementedError`` bodies
+    with HLAPI v3 asyncio calls, mapping results into :class:`SnmpResponse`.
+
+    Example sketch (pysnmp 5 / 6 asyncio HLAPI)::
+
+        from pysnmp.hlapi.asyncio import getCmd, CommunityData, UdpTransportTarget, ...
+
+        async def send_get(self, request):
+            error_indication, error_status, error_index, var_binds = await getCmd(...)
+            if error_indication:
+                raise SnmpTransportError(request.host, str(error_indication))
+            ...
+    """
+
+    def __init__(self) -> None:
+        self._closed = False
+
+    async def send_get(self, request: SnmpGetRequest) -> SnmpResponse:
+        self._ensure_open()
+        raise NotImplementedError(
+            "PysnmpBackend.send_get requires the pysnmp package. "
+            "Install pysnmp and implement HLAPI mapping, or use StubSnmpBackend."
+        )
+
+    async def send_set(self, request: SnmpSetRequest) -> SnmpResponse:
+        self._ensure_open()
+        raise NotImplementedError(
+            "PysnmpBackend.send_set requires the pysnmp package. "
+            "Install pysnmp and implement HLAPI mapping, or use StubSnmpBackend."
+        )
+
+    async def start_trap_listener(
+        self,
+        listen_host: str,
+        listen_port: int,
+        callback: TrapCallback,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> TrapSubscription:
+        self._ensure_open()
+        raise NotImplementedError(
+            "PysnmpBackend.start_trap_listener requires pysnmp ntfrcv."
+        )
+
+    async def stop_trap_listener(self, subscription: TrapSubscription) -> None:
+        self._ensure_open()
+        raise NotImplementedError("PysnmpBackend.stop_trap_listener requires pysnmp.")
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise SnmpTransportError("localhost", "pysnmp backend is closed")
+
+
+# Convenience alias documenting the preferred production backend name.
+PreferredSnmpBackend = PysnmpBackend

--- a/src/ntcip/protocol/interfaces.py
+++ b/src/ntcip/protocol/interfaces.py
@@ -1,0 +1,101 @@
+"""
+Layer 1 interfaces (SOLID: Dependency Inversion).
+
+Business and MIB layers depend on these Protocols; concrete SNMP libraries
+are injected at composition time.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, Sequence, runtime_checkable
+
+from ntcip.protocol.models import (
+    SnmpCredentials,
+    SnmpGetRequest,
+    SnmpResponse,
+    SnmpSetRequest,
+    SnmpVarBind,
+    TrapCallback,
+    TrapSubscription,
+)
+
+
+@runtime_checkable
+class SnmpBackend(Protocol):
+    """
+    Low-level adapter around a concrete SNMP library (e.g. pysnmp).
+
+    Implement this Protocol to plug in an alternate engine without changing
+    Layer 2/3 code. See :mod:`ntcip.protocol.backends`.
+    """
+
+    async def send_get(self, request: SnmpGetRequest) -> SnmpResponse:
+        """Issue a GET (or GET-NEXT batch) and return normalized varbinds."""
+
+    async def send_set(self, request: SnmpSetRequest) -> SnmpResponse:
+        """Issue a SET and return the echoed varbinds."""
+
+    async def start_trap_listener(
+        self,
+        listen_host: str,
+        listen_port: int,
+        callback: TrapCallback,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> TrapSubscription:
+        """Begin receiving SNMP traps/informs asynchronously."""
+
+    async def stop_trap_listener(self, subscription: TrapSubscription) -> None:
+        """Tear down a previously created trap listener."""
+
+    async def close(self) -> None:
+        """Release sockets and library resources."""
+
+
+@runtime_checkable
+class SnmpEngine(Protocol):
+    """
+    Application-facing async SNMP API used by the NTCIP Manager facade.
+
+    Provides timeout/retry policy and a stable promise-style
+    (``asyncio.Future`` / awaitable) surface over :class:`SnmpBackend`.
+    """
+
+    async def get_async(
+        self,
+        host: str,
+        oids: Sequence[str],
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        port: int = 161,
+        timeout_seconds: float = 2.0,
+        retries: int = 1,
+    ) -> SnmpResponse:
+        """Asynchronously GET one or more OIDs from a field device."""
+
+    async def set_async(
+        self,
+        host: str,
+        varbinds: Sequence[SnmpVarBind],
+        *,
+        credentials: Optional[SnmpCredentials] = None,
+        port: int = 161,
+        timeout_seconds: float = 2.0,
+        retries: int = 1,
+    ) -> SnmpResponse:
+        """Asynchronously SET one or more OID values on a field device."""
+
+    async def subscribe_to_traps(
+        self,
+        callback: TrapCallback,
+        *,
+        listen_host: str = "0.0.0.0",
+        listen_port: int = 162,
+        credentials: Optional[SnmpCredentials] = None,
+    ) -> TrapSubscription:
+        """Subscribe to inbound traps; invoke ``callback`` per notification."""
+
+    async def unsubscribe_from_traps(self, subscription: TrapSubscription) -> None:
+        """Cancel a trap subscription."""
+
+    async def close(self) -> None:
+        """Shut down the engine and underlying backend."""

--- a/src/ntcip/protocol/models.py
+++ b/src/ntcip/protocol/models.py
@@ -1,0 +1,101 @@
+"""
+Transport-level SNMP models used by Layer 1.
+
+These types intentionally stay library-agnostic so a pysnmp, Net-SNMP, or
+custom backend can map them without leaking vendor APIs upward.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Optional, Sequence, Tuple
+
+
+class SnmpVersion(str, Enum):
+    """Supported SNMP protocol versions (NTCIP 1103 profiles)."""
+
+    V1 = "1"
+    V2C = "2c"
+    V3 = "3"
+
+
+@dataclass(frozen=True)
+class SnmpCredentials:
+    """
+    Authentication material for an SNMP target.
+
+    For v1/v2c, ``community`` is required. For v3, supply USM fields.
+    """
+
+    community: str = "public"
+    version: SnmpVersion = SnmpVersion.V2C
+    # SNMPv3 USM (optional)
+    username: Optional[str] = None
+    auth_key: Optional[str] = None
+    priv_key: Optional[str] = None
+    auth_protocol: Optional[str] = None  # e.g. "SHA", "MD5"
+    priv_protocol: Optional[str] = None  # e.g. "AES", "DES"
+
+
+@dataclass(frozen=True)
+class SnmpVarBind:
+    """A single OID/value binding in an SNMP PDU."""
+
+    oid: str
+    value: Any = None
+    asn1_type: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SnmpGetRequest:
+    """Async GET request parameters."""
+
+    host: str
+    oids: Tuple[str, ...]
+    credentials: SnmpCredentials = field(default_factory=SnmpCredentials)
+    port: int = 161
+    timeout_seconds: float = 2.0
+    retries: int = 1
+
+
+@dataclass(frozen=True)
+class SnmpSetRequest:
+    """Async SET request parameters."""
+
+    host: str
+    varbinds: Tuple[SnmpVarBind, ...]
+    credentials: SnmpCredentials = field(default_factory=SnmpCredentials)
+    port: int = 161
+    timeout_seconds: float = 2.0
+    retries: int = 1
+
+
+@dataclass(frozen=True)
+class SnmpResponse:
+    """Normalized response from any SNMP backend."""
+
+    host: str
+    varbinds: Tuple[SnmpVarBind, ...]
+    request_id: Optional[int] = None
+    error_status: int = 0
+    error_index: int = 0
+
+
+TrapCallback = Callable[[SnmpResponse], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class TrapSubscription:
+    """Handle returned by :meth:`SnmpEngine.subscribe_to_traps`."""
+
+    listen_host: str
+    listen_port: int
+    subscription_id: str
+
+
+def as_oid_tuple(oids: Sequence[str]) -> Tuple[str, ...]:
+    """Normalize a sequence of OID strings to an immutable tuple."""
+    if not oids:
+        raise ValueError("At least one OID is required")
+    return tuple(oids)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
 # tests/conftest.py
+import sys
+from pathlib import Path
+
 import pytest
 
-@pytest.fixture(scope='module')
+# Ensure src/ is importable even when a tests/ subtree shares a package name.
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.fixture(scope="module")
 def sample_fixture():
     return "sample"

--- a/tests/its/test_profile.py
+++ b/tests/its/test_profile.py
@@ -1,0 +1,22 @@
+"""Tests for device profile loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from its.profile import device_profile_from_dict, load_device_profile
+
+
+def test_load_signals_demo_profile():
+    root = Path(__file__).resolve().parents[2]
+    profile = load_device_profile(root / "profiles" / "examples" / "signals_demo.json")
+    assert profile.domain == "signals"
+    assert profile.supports("get_phase_status")
+    assert profile.endpoint.startswith("192.0.2.")
+
+
+def test_missing_required_field():
+    with pytest.raises(ValueError):
+        device_profile_from_dict({"profile_id": "x"})

--- a/tests/its/test_shadow_and_policy.py
+++ b/tests/its/test_shadow_and_policy.py
@@ -1,0 +1,60 @@
+"""Tests for shadow bus and example policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from its.domains.signals_adapter import SignalsNtcipAdapter
+from its.events import Recommendation
+from its.policies.phase_green_monitor import PhaseGreenMonitorPolicy
+from its.profile import device_profile_from_dict
+from its.shadow import ShadowBus
+
+
+def _demo_profile():
+    return device_profile_from_dict(
+        {
+            "profile_id": "test.signals",
+            "domain": "signals",
+            "display_name": "Test",
+            "protocol": "ntcip",
+            "endpoint": "192.0.2.10",
+            "capabilities": ["get_phase_status"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_bus_records():
+    bus = ShadowBus()
+    rec = Recommendation(intent="x", reason="y", profile_id="p")
+    bus.record(rec)
+    assert len(bus.records) == 1
+    assert bus.to_dicts()[0]["intent"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_phase_green_monitor_recommends_on_mismatch():
+    adapter = SignalsNtcipAdapter()
+    policy = PhaseGreenMonitorPolicy(expected_greens=(1, 6))
+    profile = _demo_profile()
+    try:
+        observation = await policy.observe(adapter, profile)
+        recs = await policy.evaluate(observation)
+        assert len(recs) == 1
+        assert recs[0].intent == "operator_verify_intersection"
+    finally:
+        await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_phase_green_monitor_silent_when_match():
+    adapter = SignalsNtcipAdapter()
+    policy = PhaseGreenMonitorPolicy(expected_greens=(2, 5))
+    profile = _demo_profile()
+    try:
+        observation = await policy.observe(adapter, profile)
+        recs = await policy.evaluate(observation)
+        assert recs == []
+    finally:
+        await adapter.close()

--- a/tests/its/test_signals_adapter.py
+++ b/tests/its/test_signals_adapter.py
@@ -1,0 +1,46 @@
+"""Tests for signals domain adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from its.domains.signals_adapter import SignalsNtcipAdapter
+from its.profile import device_profile_from_dict
+
+
+@pytest.fixture
+def profile():
+    return device_profile_from_dict(
+        {
+            "profile_id": "test.signals",
+            "domain": "signals",
+            "display_name": "Test ASC",
+            "protocol": "ntcip",
+            "endpoint": "192.0.2.10",
+            "capabilities": ["get_phase_status", "set_timing_plan"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_status(profile):
+    adapter = SignalsNtcipAdapter()
+    try:
+        status = await adapter.get_status(profile)
+        assert status.domain == "signals"
+        assert status.data["green_phases"] == [2, 5]
+    finally:
+        await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_apply_dry_run_default(profile):
+    adapter = SignalsNtcipAdapter()
+    try:
+        result = await adapter.apply(
+            profile, "set_timing_plan", plan_number=3, dry_run=True
+        )
+        assert result.dry_run is True
+        assert result.success is True
+    finally:
+        await adapter.close()

--- a/tests/its/test_stub_domains.py
+++ b/tests/its/test_stub_domains.py
@@ -1,0 +1,41 @@
+"""Smoke tests for VMS / RWIS / CCTV stubs."""
+
+from __future__ import annotations
+
+import pytest
+
+from its.domains.cctv_adapter import CctvStubAdapter
+from its.domains.rwis_adapter import RwisStubAdapter
+from its.domains.vms_adapter import VmsStubAdapter
+from its.profile import load_device_profile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.asyncio
+async def test_vms_stub():
+    profile = load_device_profile(ROOT / "profiles" / "examples" / "vms_demo.json")
+    adapter = VmsStubAdapter()
+    status = await adapter.get_status(profile)
+    assert "message" in status.data
+    result = await adapter.apply(
+        profile, "post_message", message="FOG AHEAD", dry_run=True
+    )
+    assert result.dry_run is True
+
+
+@pytest.mark.asyncio
+async def test_rwis_stub():
+    profile = load_device_profile(ROOT / "profiles" / "examples" / "rwis_demo.json")
+    status = await RwisStubAdapter().get_status(profile)
+    assert "air_temp_c" in status.data
+
+
+@pytest.mark.asyncio
+async def test_cctv_stub():
+    profile = load_device_profile(ROOT / "profiles" / "examples" / "cctv_demo.json")
+    adapter = CctvStubAdapter()
+    status = await adapter.get_status(profile)
+    assert "presets" in status.data

--- a/tests/ntcip/business/test_manager.py
+++ b/tests/ntcip/business/test_manager.py
@@ -1,0 +1,56 @@
+"""Tests for NtcipManager business facade."""
+
+from __future__ import annotations
+
+import pytest
+
+from ntcip.business.intents import SetSignalTimingPlan
+from ntcip.exceptions import BusinessLogicError
+from ntcip.factory import create_ntcip_manager
+
+
+@pytest.mark.asyncio
+async def test_get_phase_status_typed_response():
+    manager = create_ntcip_manager(demo_data=True)
+    try:
+        snapshot = await manager.get_phase_status("192.0.2.10")
+        assert snapshot.host == "192.0.2.10"
+        assert snapshot.green_phases() == [2, 5]
+        assert snapshot.summary()[2] == "G"
+        assert snapshot.summary()[1] == "R"
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_get_unit_identity():
+    manager = create_ntcip_manager(demo_data=True)
+    try:
+        identity = await manager.get_unit_identity("192.0.2.10")
+        assert identity.unit_id == "ASC-DEMO-001"
+        assert identity.unit_location == "Main St & 1st Ave"
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_set_timing_plan_validation():
+    manager = create_ntcip_manager(demo_data=True)
+    try:
+        with pytest.raises(BusinessLogicError):
+            await manager.set_signal_timing_plan(
+                SetSignalTimingPlan(host="192.0.2.10", plan_number=0)
+            )
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_set_timing_plan_success():
+    manager = create_ntcip_manager(demo_data=True)
+    try:
+        await manager.set_signal_timing_plan(
+            SetSignalTimingPlan(host="192.0.2.10", plan_number=3)
+        )
+    finally:
+        await manager.close()

--- a/tests/ntcip/mib/test_date_and_time.py
+++ b/tests/ntcip/mib/test_date_and_time.py
@@ -1,0 +1,48 @@
+"""Tests for NTCIP DateAndTime codec."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from ntcip.exceptions import Asn1CodecError
+from ntcip.mib.date_and_time import NtcipDateAndTime
+
+
+def test_round_trip_octets():
+    original = NtcipDateAndTime(2026, 8, 3, 14, 30, 45, 7)
+    encoded = original.to_octets()
+    assert len(encoded) == 8
+    assert encoded[0] == 0x07 and encoded[1] == 0xEA  # 2026
+    decoded = NtcipDateAndTime.from_octets(encoded)
+    assert decoded == original
+
+
+def test_parse_and_format_hyphenated():
+    text = "2026-08-03-14-30-45-7"
+    value = NtcipDateAndTime.parse(text)
+    assert value.format() == text
+    assert str(value) == text
+
+
+def test_from_datetime_deci_seconds():
+    dt = datetime(2026, 1, 2, 3, 4, 5, 600_000)
+    value = NtcipDateAndTime.from_datetime(dt)
+    assert value.deci_second == 6
+    assert value.to_datetime().microsecond == 600_000
+
+
+def test_invalid_length_raises():
+    with pytest.raises(Asn1CodecError):
+        NtcipDateAndTime.from_octets(b"\x00\x01\x02")
+
+
+def test_invalid_month_raises():
+    with pytest.raises(Asn1CodecError):
+        NtcipDateAndTime(2026, 13, 1, 0, 0, 0, 0)
+
+
+def test_parse_bad_field_count():
+    with pytest.raises(Asn1CodecError):
+        NtcipDateAndTime.parse("2026-08-03")

--- a/tests/ntcip/mib/test_registry.py
+++ b/tests/ntcip/mib/test_registry.py
@@ -1,0 +1,59 @@
+"""Tests for MIB registry and mapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from ntcip.exceptions import OidMismatchError, OidNotFoundError
+from ntcip.mib.date_and_time import NtcipDateAndTime
+from ntcip.mib.mapper import DefaultMibObjectMapper
+from ntcip.mib.objects.asc_1202 import PHASE_STATUS_GROUP_GREENS_OID, PhaseStatusGroup
+from ntcip.mib.objects.global_1201 import UNIT_ID_OID, UNIT_LOCATION_OID
+from ntcip.mib.registry import build_default_ntcip_registry
+from ntcip.protocol.models import SnmpVarBind
+
+
+def test_default_registry_contains_1201_and_1202():
+    registry = build_default_ntcip_registry()
+    assert UNIT_ID_OID in registry
+    assert UNIT_LOCATION_OID in registry
+    assert PHASE_STATUS_GROUP_GREENS_OID in registry
+    unit = registry.get_by_name("unitID")
+    assert unit.standard == "NTCIP 1201"
+    phase = registry.get_by_name("phaseStatusGroupGreens")
+    assert phase.standard == "NTCIP 1202"
+
+
+def test_mapper_decodes_phase_status():
+    mapper = DefaultMibObjectMapper(build_default_ntcip_registry())
+    vb = SnmpVarBind(
+        oid=PHASE_STATUS_GROUP_GREENS_OID,
+        value=bytes([0b00010010]),
+        asn1_type="OCTET STRING",
+    )
+    domain = mapper.to_domain_as(vb, PhaseStatusGroup)
+    assert domain.active_phases() == [2, 5]
+
+
+def test_mapper_decodes_date_and_time():
+    mapper = DefaultMibObjectMapper(build_default_ntcip_registry())
+    raw = NtcipDateAndTime(2026, 8, 3, 12, 0, 0, 0).to_octets()
+    vb = SnmpVarBind(
+        oid="1.3.6.1.4.1.1206.4.2.6.3.2.0",
+        value=raw,
+        asn1_type="DateAndTime",
+    )
+    value = mapper.to_domain_as(vb, NtcipDateAndTime)
+    assert value.year == 2026 and value.month == 8
+
+
+def test_oid_not_found():
+    registry = build_default_ntcip_registry()
+    with pytest.raises(OidNotFoundError):
+        registry.get_by_oid("1.2.3.4.5")
+
+
+def test_oid_type_mismatch():
+    mapper = DefaultMibObjectMapper(build_default_ntcip_registry())
+    with pytest.raises(OidMismatchError):
+        mapper.validate_type(UNIT_ID_OID, "INTEGER")

--- a/tests/ntcip/protocol/test_async_engine.py
+++ b/tests/ntcip/protocol/test_async_engine.py
@@ -1,0 +1,84 @@
+"""Tests for async SNMP engine (timeouts, auth, GET/SET)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ntcip.exceptions import SnmpAuthenticationError, SnmpTimeoutError
+from ntcip.protocol.async_engine import AsyncSnmpEngine
+from ntcip.protocol.backends import StubSnmpBackend
+from ntcip.protocol.models import SnmpCredentials, SnmpVarBind
+
+
+@pytest.mark.asyncio
+async def test_get_async_returns_seeded_value():
+    backend = StubSnmpBackend()
+    backend.seed("1.2.3", 42, "INTEGER")
+    engine = AsyncSnmpEngine(backend)
+    try:
+        response = await engine.get_async("192.0.2.1", ["1.2.3"])
+        assert response.varbinds[0].value == 42
+    finally:
+        await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_set_async_updates_value():
+    backend = StubSnmpBackend()
+    engine = AsyncSnmpEngine(backend)
+    try:
+        await engine.set_async(
+            "192.0.2.1",
+            [SnmpVarBind(oid="1.2.3", value=7, asn1_type="INTEGER")],
+        )
+        response = await engine.get_async("192.0.2.1", ["1.2.3"])
+        assert response.varbinds[0].value == 7
+    finally:
+        await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_raised():
+    backend = StubSnmpBackend(force_timeout=True)
+    engine = AsyncSnmpEngine(backend)
+    try:
+        with pytest.raises(SnmpTimeoutError):
+            await engine.get_async(
+                "192.0.2.1",
+                ["1.2.3"],
+                timeout_seconds=0.05,
+                retries=0,
+            )
+    finally:
+        await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_authentication_failure():
+    backend = StubSnmpBackend(reject_community="bad")
+    engine = AsyncSnmpEngine(backend)
+    try:
+        with pytest.raises(SnmpAuthenticationError):
+            await engine.get_async(
+                "192.0.2.1",
+                ["1.2.3"],
+                credentials=SnmpCredentials(community="bad"),
+            )
+    finally:
+        await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_trap_subscribe_unsubscribe():
+    backend = StubSnmpBackend()
+    engine = AsyncSnmpEngine(backend)
+
+    async def _cb(_response):
+        return None
+
+    try:
+        sub = await engine.subscribe_to_traps(_cb, listen_port=1162)
+        assert sub.listen_port == 1162
+        await engine.unsubscribe_from_traps(sub)
+    finally:
+        await engine.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Positions this repo as a **multi-domain ITS systems lab** (learn / replicate / innovate) and solidifies the platform seams you will grow into -- not just an ASC NTCIP scaffold.

**Stack:** Python + asyncio + pluggable pysnmp seam (stub for offline work).

### Docs (start here when you return)

- `START_HERE.md` -- 5-minute re-entry
- `docs/ITS_LAB_STRATEGY.md` -- mission across VMS, RWIS, CCTV, signals, tunnel, airport sandbox
- `docs/ARCHITECTURE.md` -- locked seams (profiles, adapters, policies, shadow)
- `docs/ROADMAP.md` -- ordered next steps

### Architecture solidified

| Layer | Path |
|-------|------|
| Shared platform | `src/its/` -- `DeviceProfile`, `DomainAdapter`, `Policy`, `ShadowBus` |
| NTCIP vertical | `src/ntcip/` -- protocol / MIB / `NtcipManager` |
| Signals bridge | `SignalsNtcipAdapter` (real path into NTCIP) |
| Stubs ready to deepen | VMS, RWIS, CCTV adapters |
| Ops artifacts | `profiles/`, `playbooks/`, `captures/`, `domains/`, `airport_lab/` |

### Demos / tests

```bash
PYTHONPATH=src python -m its      # shadow policy demo
PYTHONPATH=src python -m ntcip    # NTCIP phase status
make test-lab                     # 30 passed (its + ntcip)
```

## Test plan

- [x] `pytest -v tests/its tests/ntcip` (30 passed)
- [x] `python -m its` shadow recommendation path
- [x] `python -m ntcip` ASC stub GET
- [ ] Wire pysnmp + second domain (VMS or RWIS) when you return -- see `docs/ROADMAP.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc4f1-57e3-7650-9fd6-882037cf9b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc4f1-57e3-7650-9fd6-882037cf9b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

